### PR TITLE
Add imports to ssh::server::service

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,4 +1,7 @@
 class ssh::server::service {
+    include ssh::params
+    include ssh::server
+
     service { $ssh::params::service_name:
         ensure     => running,
         hasstatus  => true,


### PR DESCRIPTION
Includes ssh::params and include ssh::server in server/service.pp
so that 

class { 'ssh::server::service': }

doesn't fail
