### PR TITLE
Export ECDSA hostkeys

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -17,5 +17,6 @@ class ssh::hostkeys {
       host_aliases => $host_aliases,
       type         => 'ecdsa-sha2-nistp256',
       key          => $::sshecdsakey,
+    }
   }
 }


### PR DESCRIPTION
Since these are only available with a combination of both a recent
openssh and a recent facter, I've made it conditional on the presence of
the sshecdsakey fact.
