### PR TITLE
added support for archlinux:

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,6 +1,16 @@
 class ssh::client {
-  include ssh::params
-  include ssh::client::install
-  include ssh::client::config
-  include ssh::knownhosts
+case $::operatingsystem {
+        Archlinux:{
+          include ssh::params
+          include ssh::client::config
+          include ssh::knownhosts
+        }
+        default: {
+          include ssh::params
+          include ssh::client::install
+          include ssh::client::config
+          include ssh::knownhosts
+        }
+      }
+
 }

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -4,7 +4,10 @@ class ssh::client::config {
     owner   => 'root',
     group   => 'root',
     source  => "puppet:///modules/${module_name}/ssh_config",
-    require => Class['ssh::client::install'],
+    require => $operatingsystem ? {
+      Archlinux => undef,
+      default => Class['ssh::client::install'],
+      }
   }
 
   # Workaround for http://projects.reductivelabs.com/issues/2014

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,13 @@ class ssh::params {
     }
     default: {
       case $::operatingsystem {
+        Archlinux:{
+          $server_package_name = 'openssh'
+          $sshd_config = '/etc/ssh/sshd_config'
+          $ssh_config = '/etc/ssh/ssh_config'
+          $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+          $service_name = 'sshd'
+        }
         default: {
           fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
         }


### PR DESCRIPTION
archlinux has only one package openssh,
which provides client and server.

modified client install to mimic, without touching the modules logic.
