### PR TITLE
Adding changes to prevent storeconfigs warnings.

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -2,21 +2,18 @@ class ssh::hostkeys {
   $ipaddresses = ipaddresses()
   $host_aliases = flatten([ $::fqdn, $::hostname, $ipaddresses ])
 
-  @@sshkey { "${::fqdn}_dsa":
-    host_aliases => $host_aliases,
-    type         => dsa,
-    key          => $::sshdsakey,
-  }
-  @@sshkey { "${::fqdn}_rsa":
-    host_aliases => $host_aliases,
-    type         => rsa,
-    key          => $::sshrsakey,
-  }
-  if $::sshecdsakey {
-    @@sshkey { "${::fqdn}_ecdsa":
-      host_aliases => $host_aliases,
-      type         => 'ecdsa-sha2-nistp256',
-      key          => $::sshecdsakey,
-    }
+  anchor { 'ssh::hostkeys::begin': } 
+  anchor { 'ssh::hostkeys::end': } 
+
+  if $::settings::storeconfigs {
+    include ssh::hostkeys::storeconfigs
+    Anchor['ssh::hostkeys::begin'] ->
+    Class['ssh::hostkeys::storeconfigs'] ->
+    Anchor['ssh::hostkeys::end']
+  } else {
+    include ssh::hostkeys::no_storeconfigs
+    Anchor['ssh::hostkeys::begin'] ->
+    Class['ssh::hostkeys::no_storeconfigs'] ->
+    Anchor['ssh::hostkeys::end']
   }
 }

--- a/manifests/hostkeys/no_storeconfigs.pp
+++ b/manifests/hostkeys/no_storeconfigs.pp
@@ -1,0 +1,19 @@
+class ssh::hostkeys::no_storeconfigs {
+  @sshkey { "${::fqdn}_dsa":
+    host_aliases => $host_aliases,
+    type         => dsa,
+    key          => $::sshdsakey,
+  }
+  @sshkey { "${::fqdn}_rsa":
+    host_aliases => $host_aliases,
+    type         => rsa,
+    key          => $::sshrsakey,
+  }
+  if $::sshecdsakey {
+    @sshkey { "${::fqdn}_ecdsa":
+      host_aliases => $host_aliases,
+      type         => 'ecdsa-sha2-nistp256',
+      key          => $::sshecdsakey,
+    }
+  }
+}

--- a/manifests/hostkeys/storeconfigs.pp
+++ b/manifests/hostkeys/storeconfigs.pp
@@ -1,0 +1,19 @@
+class ssh::hostkeys::storeconfigs {
+  @@sshkey { "${::fqdn}_dsa":
+    host_aliases => $host_aliases,
+    type         => dsa,
+    key          => $::sshdsakey,
+  }
+  @@sshkey { "${::fqdn}_rsa":
+    host_aliases => $host_aliases,
+    type         => rsa,
+    key          => $::sshrsakey,
+  }
+  if $::sshecdsakey {
+    @@sshkey { "${::fqdn}_ecdsa":
+      host_aliases => $host_aliases,
+      type         => 'ecdsa-sha2-nistp256',
+      key          => $::sshecdsakey,
+    }
+  }
+}

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -1,5 +1,17 @@
 class ssh::knownhosts {
-  Sshkey <<| |>> {
-    ensure => present,
+
+  anchor { 'ssh::knownhosts::begin': } 
+  anchor { 'ssh::knownhosts::end': } 
+
+  if $::settings::storeconfigs {
+    include ssh::knownhosts::storeconfigs
+    Anchor['ssh::knownhosts::begin'] ->
+    Class['ssh::knownhosts::storeconfigs'] ->
+    Anchor['ssh::knownhosts::end']
+  } else {
+    include ssh::knownhosts::no_storeconfigs
+    Anchor['ssh::knownhosts::begin'] ->
+    Class['ssh::knownhosts::no_storeconfigs'] ->
+    Anchor['ssh::knownhosts::end']
   }
 }

--- a/manifests/knownhosts/no_storeconfigs.pp
+++ b/manifests/knownhosts/no_storeconfigs.pp
@@ -1,0 +1,5 @@
+class ssh::knownhosts::no_storeconfigs {
+  Sshkey <| |> {
+    ensure => present,
+  }
+}

--- a/manifests/knownhosts/storeconfigs.pp
+++ b/manifests/knownhosts/storeconfigs.pp
@@ -1,0 +1,5 @@
+class ssh::knownhosts::storeconfigs {
+  Sshkey <<| |>> {
+    ensure => present,
+  }
+}


### PR DESCRIPTION
If you are not using a storeconfig_backend or and storeconfigs is set to false in the case of some masterless puppet setups this module throws the following warning:

Warning: You cannot collect without storeconfigs being set on line 11 in file puppet/modules/ssh/manifests/hostkeys.pp
Warning: You cannot collect without storeconfigs being set on line 16 in file puppet/modules/ssh/manifests/hostkeys.pp
Warning: You cannot collect without storeconfigs being set on line 22 in file puppet/modules/ssh/manifests/hostkeys.pp
Warning: You cannot collect exported resources without storeconfigs being set; the collection will be ignored on line 4 in file puppet/modules/ssh/manifests/knownhosts.pp
Warning: Not collecting exported resources without storeconfigs
Warning: Not collecting exported resources without storeconfigs
Warning: Not collecting exported resources without storeconfigs

These warnings clutter up the puppet output and it would be great to remove them from the output. Without the contains syntax it adds a good amount more configuration wise but it doesn't through any parser errors with this configuration.

Im totally open to other suggestions on implementation. I would really like to use this module and this is currently a blocker for our implementation.
