### PR TITLE
Make logic explicit in template.

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -1,6 +1,6 @@
 # File is managed by Puppet
 
-<%- scope.lookupvar('ssh::server::merged_options').sort_by{ |sk, sv| sk.to_s.downcase.include? "match" ? sk.to_s : '' }.each do |k, v| -%>
+<%- scope.lookupvar('ssh::server::merged_options').sort_by{ |sk, sv| (sk.to_s.downcase.include? "match" )? sk.to_s : '' }.each do |k, v| -%>
 <%- if v.is_a?(Hash) -%>
 <%= k %>
 <%- v.sort.each do |key, value| -%>


### PR DESCRIPTION
I see this warning when I render this template:
modules/ssh/templates/sshd_config.erb:3: warning: string literal in condition
Im not sure if this effects all versions of ruby or what. I think that this was your intension. Let me know if this isn't want you wanted here.

On:
ubuntu
ruby 1.9.3p0
puppet 3.4.3
