### PR TITLE
Correctly order sshd options

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -1,6 +1,6 @@
 # File is managed by Puppet
 
-<%- scope.lookupvar('ssh::server::merged_options').sort_by{ |sk| (sk.to_s.downcase.include? "match") ? sk.to_s : '' }.each do |k, v| -%>
+<%- scope.lookupvar('ssh::server::merged_options').sort_by{ |sk| (sk.to_s.downcase.include? "match") ? "zzz" + sk.to_s : sk.to_s }.each do |k, v| -%>
 <%- if v.is_a?(Hash) -%>
 <%= k %>
 <%- v.sort.each do |key, value| -%>


### PR DESCRIPTION
Options hash should be ordered in order not to modify file in every puppet execution. The previous patch, although warranties that Match option is the last one, the other options were unordered. This patch warranties that Match option is the last, but the rest are still ordered.
