### PR TITLE
add support for Archlinux

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,16 @@ class ssh::params {
       $service_name = 'sshd'
       $sftp_server_path = '/usr/lib/openssh/sftp-server'
     }
+    Archlinux: {
+      $server_package_name = 'openssh'
+      $client_package_name = 'openssh'
+      $sshd_dir = '/etc/ssh'
+      $sshd_config = '/etc/ssh/sshd_config'
+      $ssh_config = '/etc/ssh/ssh_config'
+      $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+      $service_name = 'sshd.service'
+      $sftp_server_path = '/usr/lib/ssh/sftp-server'
+    }
     default: {
       case $::operatingsystem {
         gentoo: {


### PR DESCRIPTION
This adds support in params.pp for Archlinux.

It looks like most of the OS varieties don't have rspec tests (that I could find) so I didn't add any, but gladly will if desired. This works correctly on both of my Arch boxes.
