### PR TITLE
Implement Consistent Option Ordering

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -1,12 +1,12 @@
 # File is managed by Puppet
-<%- if port = scope.lookupvar('ssh::server::merged_options').delete('Port') -%>
+<%- options = scope.lookupvar('ssh::server::merged_options') -%>
+<%- if port = options.delete('Port') -%>
 Port <%= port %>
 <%- end -%>
-<%- if listen = scope.lookupvar('ssh::server::merged_options').delete('ListenAddress') -%>
+<%- if listen = options.delete('ListenAddress') -%>
 ListenAddress <%= listen %>
 <%- end -%>
 
-<%- options = scope.lookupvar('ssh::server::merged_options') -%>
 <%- options.keys.sort_by{ |sk| (sk.to_s.downcase.include? "match") ? 'zzz' + sk.to_s : sk.to_s }.each do |k| -%>
 <%- v = options[k] -%>
 <%- if v.is_a?(Hash) -%>


### PR DESCRIPTION
This resolves issue https://github.com/saz/puppet-ssh/issues/31 by plucking the Port and ListenAddress options from the options hash and putting them in at the top in the correct order required by sshd.

It also implements and extends https://github.com/saz/puppet-ssh/pull/29 so that remaining options are consistently ordered between runs.  It sorts the option keys as an array so it should also work in ruby 1.8.7 which from my understanding, does not understand hash sorting.
