### PR TITLE
Allow to undefine default options in sshd_config.

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -38,7 +38,7 @@ ListenAddress <%= listen %>
 <%- v.each do |a| -%>
 <%= k %> <%= a %>
 <%- end -%>
-<%- else -%>
+<%- elsif v != :undef -%>
 <%= k %> <%= v %>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
This allows us to undefine the "Subsystem" option.
