### PR TITLE
Bug: AddressFamily must be specified before ListenAddress

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -1,5 +1,8 @@
 # File is managed by Puppet
 <%- options = scope.lookupvar('ssh::server::merged_options') -%>
+<%- if addressfamily = options.delete('AddressFamily') -%>
+AddressFamily <%= addressfamily %>
+<%- end -%>
 <%- if port = options.delete('Port') -%>
 <%- if port.is_a?(Array) -%>
 <%- port.each do |p| -%>


### PR DESCRIPTION
This hopefully fix this issue:
    # /usr/sbin/sshd -D
    /etc/ssh/sshd_config line 5: address family must be specified before ListenAddress.
