### PR TITLE
Fix readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,7 +19,7 @@ port 22 and 2222) should be passed as an array.
 
 ```
     options => {
-      Port => [22, 2222],
+      'Port' => [22, 2222],
     }
 ```
 
@@ -46,7 +46,7 @@ or
           'AllowTcpForwarding' => 'no',
           'X11Forwarding' => 'no',
         },
-        Port => [22, 2222, 2288],
+        'Port' => [22, 2222, 2288],
       },
       client_options => {
         'Host *.amazonaws.com' => {


### PR DESCRIPTION
Module can't work with Port (with capital letter P and without quotes). 

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Could not parse for environment production: Syntax error at 'Port'; expected '}' at /etc/puppet/manifests/linux/kirova54/node.pp:81 on node node

Need to use 'Port' or port.
