### PR TITLE
Ensure ssh_known_hosts is present.

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -9,6 +9,7 @@ class ssh::client::config {
 
   # Workaround for http://projects.reductivelabs.com/issues/2014
   file { $ssh::params::ssh_known_hosts:
+    ensure => present,
     mode => '0644',
   }
 }


### PR DESCRIPTION
If the file ssh_known_hosts is not present it won't be managed
by puppet. This commit adds 'ensure => present' so the file
will be created if it is missing.

It might be a desireable to only 'ensure => present' when
storeconfigs_enabled is set to true. Someone with more puppet
knowledge should do this.
