### PR TITLE
make all sshkeys conditional

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -2,15 +2,19 @@ class ssh::hostkeys {
   $ipaddresses = ipaddresses()
   $host_aliases = flatten([ $::fqdn, $::hostname, $ipaddresses ])
 
-  @@sshkey { "${::fqdn}_dsa":
-    host_aliases => $host_aliases,
-    type         => dsa,
-    key          => $::sshdsakey,
+  if $::sshdsakey {
+    @@sshkey { "${::fqdn}_dsa":
+      host_aliases => $host_aliases,
+      type         => dsa,
+      key          => $::sshdsakey,
+    }
   }
-  @@sshkey { "${::fqdn}_rsa":
-    host_aliases => $host_aliases,
-    type         => rsa,
-    key          => $::sshrsakey,
+  if $::sshrsakey {
+    @@sshkey { "${::fqdn}_rsa":
+      host_aliases => $host_aliases,
+      type         => rsa,
+      key          => $::sshrsakey,
+    }
   }
   if $::sshecdsakey {
     @@sshkey { "${::fqdn}_ecdsa":


### PR DESCRIPTION
Just installed a Fedora 20 machine, it only has sshecdsakey and sshrsakey, not sshdsakey
