### PR TITLE
bugfix: don't set undef values in ssh_config

### DIFF
--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -17,7 +17,7 @@
 <%- v.each do |a| -%>
 <%= k %> <%= a %>
 <%- end -%>
-<%- else -%>
+<%- elsif v != :undef -%>
 <%= k %> <%= v %>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Analogous to the check already done here: https://github.com/saz/puppet-ssh/blob/master/templates/sshd_config.erb#L44
Don't set values in the client config, that are configured to be empty (i.e. `undef` in puppet).

Signed-off-by: Dominik Richter dominik.richter@gmail.com
