### PR TITLE
Corrected sftp_server_path for RedHat/CentOS 6

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,14 @@ class ssh::params {
       $ssh_config = '/etc/ssh/ssh_config'
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       $service_name = 'sshd'
-      $sftp_server_path = '/usr/lib/openssh/sftp-server'
+      case $lsbmajdistrelease {
+        6: {
+          $sftp_server_path = '/usr/libexec/openssh/sftp-server'
+        }
+        default: {
+          $sftp_server_path = '/usr/lib/openssh/sftp-server'
+        }
+      }
     }
     freebsd: {
       $server_package_name = undef


### PR DESCRIPTION
At least in CentOS 6.5 the path is different form the stated one:

Details from the tested system:

```
# facter | grep lsb
lsbdistcodename => Final
lsbdistdescription => CentOS release 6.5 (Final)
lsbdistid => CentOS
lsbdistrelease => 6.5
lsbmajdistrelease => 6
lsbrelease => :base-4.0-amd64:base-4.0-noarch:core-4.0-amd64:core-4.0-noarch:graphics-4.0-amd64:graphics-4.0-noarch:printing-4.0-amd64:printing-4.0-noarch
```
