### PR TITLE
config.pp: Change owner / group to string from int

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,8 +1,8 @@
 class ssh::server::config {
   concat { $ssh::params::sshd_config:
     ensure => present,
-    owner  => 0,
-    group  => 0,
+    owner  => 'root',
+    group  => 'root',
     mode   => '0600',
   }
 


### PR DESCRIPTION
Need to supply a string to `owner` and `group` to squash the puppet message:

    Error 400 on SERVER: 0 is not a string.  It looks to be a Fixnum on node <client>