### PR TITLE
Add explicit allow_virtual parameters. Fixes #71

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -2,7 +2,8 @@ class ssh::client::install {
   if $ssh::params::client_package_name {
     if !defined(Package[$ssh::params::client_package_name]) {
       package { $ssh::params::client_package_name:
-        ensure => $ssh::client::ensure,
+        ensure        => $ssh::client::ensure,
+        allow_virtual => false,
       }
     }
   }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -3,7 +3,8 @@ class ssh::server::install {
   if $ssh::params::server_package_name {
     if !defined(Package[$ssh::params::server_package_name]) {
       package { $ssh::params::server_package_name:
-        ensure   => $ssh::server::ensure,
+        ensure        => $ssh::server::ensure,
+        allow_virtual => false,
       }
     }
   }


### PR DESCRIPTION
As the default will change, a warning is issued if this is not explicitly stated
with puppet 3.7.3.