### PR TITLE
Add support for OpenBSD

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -1,8 +1,8 @@
 class ssh::client::config {
   file { $ssh::params::ssh_config:
     ensure  => present,
-    owner   => 0,
-    group   => 0,
+    owner   => '0',
+    group   => '0',
     content => template("${module_name}/ssh_config.erb"),
     require => Class['ssh::client::install'],
   }

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -23,4 +23,11 @@ class ssh::hostkeys {
       key          => $::sshecdsakey,
     }
   }
+  if $::sshed25519key {
+    @@sshkey { "${::fqdn}_ed25519":
+      host_aliases => $host_aliases,
+      type         => 'ssh-ed25519',
+      key          => $::sshed25519key,
+    }
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,16 @@ class ssh::params {
       $service_name = 'sshd'
       $sftp_server_path = '/usr/lib/openssh/sftp-server'
     }
+    openbsd: {
+      $server_package_name = undef
+      $client_package_name = undef
+      $sshd_dir = '/etc/ssh'
+      $sshd_config = '/etc/ssh/sshd_config'
+      $ssh_config = '/etc/ssh/ssh_config'
+      $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+      $service_name = 'sshd'
+      $sftp_server_path = '/usr/libexec/sftp-server'
+    }
     Archlinux: {
       $server_package_name = 'openssh'
       $client_package_name = 'openssh'
@@ -80,13 +90,29 @@ class ssh::params {
     }
   }
 
-  $sshd_default_options = {
-    'ChallengeResponseAuthentication' => 'no',
-    'X11Forwarding'                   => 'yes',
-    'PrintMotd'                       => 'no',
-    'AcceptEnv'                       => 'LANG LC_*',
-    'Subsystem'                       => "sftp ${sftp_server_path}",
-    'UsePAM'                          => 'yes',
+  # OpenBSDs openssh doesn't link against PAM, therefore
+  # it doesn't know about the UsePAM option
+  case $::osfamily {
+    openbsd: {
+      $sshd_default_options = {
+        'ChallengeResponseAuthentication' => 'no',
+        'X11Forwarding'                   => 'yes',
+        'PrintMotd'                       => 'no',
+        'AcceptEnv'                       => 'LANG LC_*',
+        'Subsystem'                       => "sftp ${sftp_server_path}",
+      }
+    }
+    default: {
+      $sshd_default_options = {
+        'ChallengeResponseAuthentication' => 'no',
+        'X11Forwarding'                   => 'yes',
+        'PrintMotd'                       => 'no',
+        'AcceptEnv'                       => 'LANG LC_*',
+        'Subsystem'                       => "sftp ${sftp_server_path}",
+        'UsePAM'                          => 'yes',
+      }
+
+    }
   }
 
   $ssh_default_options = {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -3,8 +3,8 @@ class ssh::server::config {
 
   concat { $ssh::params::sshd_config:
     ensure => present,
-    owner  => 0,
-    group  => 0,
+    owner  => '0',
+    group  => '0',
     mode   => '0600',
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -22,6 +22,9 @@
       "operatingsystem": "FreeBSD"
     },
     {
+      "operatingsystem": "OpenBSD"
+    },
+    {
       "operatingsystem": "Gentoo"
     },
     {


### PR DESCRIPTION
The changes to client/config.pp and server/config.pp are because
I use the future parser, just some '' around literal 0s.

Changes to params.pp to support OpenBSD, the sshd_default_params,
UsePAM, is a bit tricky, since OpenBSD sshd is not linked against
pam, therefore, the parameter is not knows to OpenBSDs sshd.
Even overriding it and setting it to 'no' or undef, didn't helped.
If there are other solutions preferred, I'd like to know.

change to hostkeys.pp is because OpenBSD supports ed25519 type
of keys, so that they get added to ssh_known_hosts file.

metadata.json, just added OpenBSD as supported OS.