### PR TITLE
Support for ed25519 hostkeys

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -23,4 +23,12 @@ class ssh::hostkeys {
       key          => $::sshecdsakey,
     }
   }
+  if $::sshed25519key {
+    @@sshkey { "${::fqdn}_ed25519":
+      host_aliases => $host_aliases,
+      type         => 'curve25519-sha256',
+      key          => $::sshed25519key,
+    }
+  }
+
 }

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -26,7 +26,7 @@ class ssh::hostkeys {
   if $::sshed25519key {
     @@sshkey { "${::fqdn}_ed25519":
       host_aliases => $host_aliases,
-      type         => 'curve25519-sha256',
+      type         => 'ssh-ed25519',
       key          => $::sshed25519key,
     }
   }


### PR DESCRIPTION
With this you can deploy ed25519 hostkeys with the host_key class from the puppetmaster.

This won't solve the problem that you can't specify multiple HostKey options in server_options. Well, you can, it takes the last one and ignores the others. 