### PR TITLE
Purge removed host keys from knownhosts file and add ed25519 support.

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -42,7 +42,7 @@ class ssh::hostkeys {
     @@sshkey { "${::fqdn}_ed25519":
       ensure       => present,
       host_aliases => $host_aliases,
-      type         => 'ssh-ed25519',
+      type         => 'ed25519',
       key          => $::sshed25519key,
     }
   } else {

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -4,23 +4,50 @@ class ssh::hostkeys {
 
   if $::sshdsakey {
     @@sshkey { "${::fqdn}_dsa":
+      ensure       => present,
       host_aliases => $host_aliases,
       type         => dsa,
       key          => $::sshdsakey,
     }
+  } else {
+    @@sshkey { "${::fqdn}_dsa":
+      ensure       => absent,
+    }
   }
   if $::sshrsakey {
     @@sshkey { "${::fqdn}_rsa":
+      ensure       => present,
       host_aliases => $host_aliases,
       type         => rsa,
       key          => $::sshrsakey,
     }
+  } else {
+    @@sshkey { "${::fqdn}_rsa":
+      ensure       => absent,
+    }
   }
   if $::sshecdsakey {
     @@sshkey { "${::fqdn}_ecdsa":
+      ensure       => present,
       host_aliases => $host_aliases,
       type         => 'ecdsa-sha2-nistp256',
       key          => $::sshecdsakey,
+    }
+  } else {
+    @@sshkey { "${::fqdn}_ecdsa":
+      ensure       => absent,
+    }
+  }
+  if $::sshed25519key {
+    @@sshkey { "${::fqdn}_ed25519":
+      ensure       => present,
+      host_aliases => $host_aliases,
+      type         => 'ssh-ed25519',
+      key          => $::sshed25519key,
+    }
+  } else {
+    @@sshkey { "${::fqdn}_ed25519":
+      ensure       => absent,
     }
   }
 }

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -1,5 +1,3 @@
 class ssh::knownhosts {
-  Sshkey <<| |>> {
-    ensure => present,
-  }
+  Sshkey <<| |>>
 }


### PR DESCRIPTION
An example use case for this is one would disable for example DSA host keys
collected earlier. Disabling DSA is considered a good security practice. To
then actually prevent an attacker to be successful in carrying out a MitM
attack using a DSA key, the public key has to be removed from the client's
`ssh_known_hosts` file for its trust to be revoked.