### PR TITLE
Add support for per user ssh configuration file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -27,7 +27,7 @@ port 22 and 2222) should be passed as an array.
 
 This is working for both, client and server.
 
-### Both client and server
+### Both client, server and per user client configuration
 Host keys will be collected and distributed unless
  `storeconfigs_enabled` is `false`.
 
@@ -55,6 +55,15 @@ or
           'User' => 'ec2-user',
         },
       },
+      users_client_options => {
+        'bob' => {
+          options => {
+            'Host *.alice.fr' => {
+              'User' => 'alice',
+            },
+          },
+        },
+      },
     }
 ```
 
@@ -77,6 +86,13 @@ ssh::client_options:
         SendEnv: 'LANG LC_*'
         ForwardX11Trusted: 'yes'
         ServerAliveInterval: '10'
+
+ssh::users_client_options:
+    'bob':
+        'options':
+            'Host *.alice.fr':
+                'User': 'alice'
+                'PasswordAuthentication': 'no'
 ```
 
 ### Client only
@@ -103,6 +119,63 @@ or
         },
       },
     }
+```
+
+### Per user client configuration
+
+**User's home is expected to be /home/bob**
+
+SSH configuration file will be `/home/bob/.ssh/config`.
+
+```puppet
+::ssh::client::config::user { 'bob':
+  ensure => present,
+  options => {
+    'HashKnownHosts' => 'yes'
+  }
+}
+```
+
+**User's home is passed to define type**
+
+SSH configuration file will be `/var/lib/bob/.ssh/config` and puppet will 
+manage directory `/var/lib/bob/.ssh`.
+
+```puppet
+::ssh::client::config::user { 'bob':
+  ensure => present,
+  user_home_dir => '/var/lib/bob',
+  options => {
+    'HashKnownHosts' => 'yes'
+  }
+}
+```
+
+**User's ssh directory should not be managed by the define type**
+
+SSH configuration file will be `/var/lib/bob/.ssh/config`.
+
+```puppet
+::ssh::client::config::user { 'bob':
+  ensure => present,
+  user_home_dir => '/var/lib/bob',
+  manage_user_ssh_dir => false,
+  options => {
+    'HashKnownHosts' => 'yes'
+  }
+}
+```
+
+**User's ssh config is specified with an absolute path**
+
+```puppet
+::ssh::client::config::user { 'bob':
+  ensure => present,
+  target => '/var/lib/bob/.ssh/ssh_config',
+  options => {
+    'HashKnownHosts' => 'yes'
+  }
+}
 ```
 
 ### Server only

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -1,4 +1,7 @@
-class ssh::client::config {
+class ssh::client::config
+{
+  $options = $::ssh::client::merged_options
+
   file { $ssh::params::ssh_config:
     ensure  => present,
     owner   => '0',

--- a/manifests/client/config/user.pp
+++ b/manifests/client/config/user.pp
@@ -1,0 +1,56 @@
+#
+# Copyright (c) IN2P3 Computing Centre, IN2P3, CNRS
+# Contributor: Remi Ferrand <remi{dot}ferrand_at_cc(dot)in2p3.fr> (2015)
+#
+define ssh::client::config::user(
+  $ensure               = present,
+  $target               = undef,
+  $user_home_dir        = undef,
+  $manage_user_ssh_dir  = true,
+  $options              = {}
+)
+{
+  validate_re($ensure, '^(present|absent)$')
+  validate_hash($options)
+  validate_bool($manage_user_ssh_dir)
+
+  include ::ssh::params
+
+  $_files_ensure = $ensure ? { 'present' => 'file', 'absent' => 'absent' }
+
+  # If a specific target file was specified,
+  # it must have higher priority than any
+  # other parameter.
+  if ($target != undef) {
+    validate_absolute_path($target)
+    $_target = $target
+  }
+  else {
+    if ($user_home_dir == undef) {
+      $_user_home_dir = "/home/${name}"
+    }
+    else {
+      validate_absolute_path($user_home_dir)
+      $_user_home_dir = $user_home_dir
+    }
+
+    $user_ssh_dir = "${_user_home_dir}/.ssh"
+    $_target      = "${user_ssh_dir}/config"
+
+    if ($manage_user_ssh_dir == true) {
+      file { $user_ssh_dir:
+        ensure => directory,
+        owner  => $name,
+        mode   => $::ssh::params::user_ssh_directory_default_mode,
+        before => File[$_target]
+      }
+    }
+  }
+  
+  file { $_target:
+    ensure  => $_files_ensure,
+    owner   => $name,
+    mode    => $::ssh::params::user_ssh_config_default_mode,
+    content => template("${module_name}/ssh_config.erb")
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,20 @@
 class ssh (
   $server_options       = {},
   $client_options       = {},
+  $users_client_options = {},
   $version              = 'present',
   $storeconfigs_enabled = true
 ) inherits ssh::params {
 
+  validate_hash($server_options)
+  validate_hash($client_options)
+  validate_hash($users_client_options)
+  validate_bool($storeconfigs_enabled)
+
   # Merge hashes from multiple layer of hierarchy in hiera
   $hiera_server_options = hiera_hash("${module_name}::server_options", undef)
   $hiera_client_options = hiera_hash("${module_name}::client_options", undef)
+  $hiera_users_client_options = hiera_hash("${module_name}::users_client_options", undef)
 
   $fin_server_options = $hiera_server_options ? {
     undef   => $server_options,
@@ -17,6 +24,11 @@ class ssh (
   $fin_client_options = $hiera_client_options ? {
     undef   => $server_options,
     default => $hiera_client_options,
+  }
+
+  $fin_users_client_options = $hiera_users_client_options ? {
+    undef   => $server_options,
+    default => $hiera_users_client_options,
   }
 
   class { 'ssh::server':
@@ -30,4 +42,6 @@ class ssh (
     options              => $fin_client_options,
     ensure               => $version,
   }
+
+  create_resources('::ssh::client::config::user', $fin_users_client_options)
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -131,4 +131,7 @@ class ssh::params {
       'HashKnownHosts'       => 'yes',
     },
   }
+
+  $user_ssh_directory_default_mode = '0700'
+  $user_ssh_config_default_mode    = '0600'
 }

--- a/spec/defines/client/config/user_spec.rb
+++ b/spec/defines/client/config/user_spec.rb
@@ -1,0 +1,167 @@
+require 'spec_helper'
+
+describe 'ssh::client::config::user', :type => :define do
+
+  let :title do
+    'riton'  
+  end
+
+  let :ssh_options do {
+    'HashKnownHosts' => 'yes',
+    'Host *.in2p3.fr' => {
+      'User' => 'riton',
+      'GSSAPIAuthentication' => 'no'
+    }
+  } end
+
+  let :facts do {
+    :osfamily       => 'RedHat',
+    :concat_basedir => '/tmp'
+  } end
+
+
+  describe 'with invalid parameters' do
+
+    params = {
+      :ensure              => [ 'somestate', 'does not' ],
+      :target              => [ './somedir', 'is not an absolute path' ],
+      :user_home_dir       => [ './somedir', 'is not an absolute path' ],
+      :manage_user_ssh_dir => [ 'maybe', 'is not a boolean' ],
+      :options             => [ 'the_options', 'is not a Hash' ]
+    }
+    
+    params.each do |param, value|
+
+      context "with invalid value for #{param.to_s}" do
+        let :params do {
+          param => value[0]
+        } end
+
+        it 'should fail' do
+          expect {
+            should compile
+          }.to raise_error(/#{value[1]}/)
+        end
+      end
+
+    end # params.each
+  end # describe 'with invalid parameters'
+
+  describe 'with correct values' do
+
+    describe 'with a user provided target' do
+
+      let :target do
+        '/root/.ssh/config'
+      end
+
+      let :params do {
+        :target  => target
+      } end
+
+      it do
+        should contain_file(target).with({
+          :ensure  => 'file',
+          :owner   => title,
+          :mode    => '0600'
+        })
+      end
+
+    end # describe 'with a user provided target'
+
+    describe 'user_home_dir behavior' do
+
+      context 'with a user provided user_home_dir' do
+
+        let :user_home_dir do
+          '/path/to/home'
+        end
+
+        context 'with manage_user_ssh_dir default value' do
+
+          let :params do {
+            :user_home_dir => user_home_dir
+          } end
+
+          it 'should contain ssh directory and ssh config' do
+
+            should contain_file("#{user_home_dir}/.ssh").with({
+              :ensure  => 'directory',
+              :owner   => title,
+              :mode    => '0700'
+            }).that_comes_before("File[#{user_home_dir}/.ssh/config]")
+
+            should contain_file("#{user_home_dir}/.ssh/config").with({
+              :ensure  => 'file',
+              :owner   => title,
+              :mode    => '0600'
+            })
+          end
+
+        end # context 'with manage_user_ssh_dir default value'
+
+        context 'with manage_user_ssh_dir set to false' do
+
+          let :params do {
+            :user_home_dir       => user_home_dir,
+            :manage_user_ssh_dir => false
+          } end
+
+          it do
+            should_not contain_file("#{user_home_dir}/.ssh")
+          end
+
+        end # context 'with manage_user_ssh_dir set to false'
+
+      end # context 'with a user provided user_home_dir'
+
+      context 'with no user provided user_home_dir' do
+        it 'with manage_user_ssh_dir default value' do
+          should contain_file("/home/#{title}/.ssh").that_comes_before("File[/home/#{title}/.ssh/config]")
+          should contain_file("/home/#{title}/.ssh/config")
+        end
+
+        context 'with manage_user_ssh_dir set to false' do
+          let :params do {
+            :manage_user_ssh_dir => false
+          } end
+
+          it do
+            should_not contain_file("/home/#{title}/.ssh")
+          end
+
+          it do
+            should contain_file("/home/#{title}/.ssh/config")
+          end
+
+        end # context 'with manage_user_ssh_dir set to false'
+
+      end # context 'with no user provided user_home_dir'
+
+    end # describe 'user_home_dir behavior'
+
+    describe 'ssh configuration content' do
+
+      let :params do {
+        :options => ssh_options
+      } end
+
+      it 'should have single value' do
+        should contain_file("/home/#{title}/.ssh/config").with({
+          :content => /HashKnownHosts\s+yes/
+        })
+      end
+
+      it 'should have Hash value' do
+        should contain_file("/home/#{title}/.ssh/config").with({
+          :content => /Host \*\.in2p3\.fr\s*\n\s+GSSAPIAuthentication\s+no\s*\n\s+User\s+riton/
+        })
+      end
+
+    end
+
+  end # describe 'with correct values'
+
+end
+
+# vim: tabstop=2 shiftwidth=2 softtabstop=2

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -11,7 +11,8 @@
     end
   end
 -%>
-<%- scope.lookupvar('ssh::client::merged_options').sort.each do |k, v| -%>
+
+<%- @options.sort.each do |k, v| -%>
 <%- if v.is_a?(Hash) -%>
 <%= k %>
 <%- v.sort.each do |key, value| -%>


### PR DESCRIPTION
At CC-IN2P3, we need to manage per user ssh configuration file like `~user/.ssh/config`.

This patch creates a new define type `ssh::client::config::user` that could be used to manage users config:

1) User's home is expected to be `/home/riton`

```puppet
::ssh::client::config::user { 'riton':
  ensure => present,
  options => {
    'HashKnownHosts' => 'yes'
  }
}
```

2) User's home is passed to define type

```puppet
::ssh::client::config::user { 'riton':
  ensure => present,
  user_home_dir => '/var/lib/riton',
  options => {
    'HashKnownHosts' => 'yes'
  }
}
```

3) User's ssh directory should not be managed by the define type

```puppet
::ssh::client::config::user { 'riton':
  ensure => present,
  user_home_dir => '/var/lib/riton',
  manage_user_ssh_dir => false,
  options => {
    'HashKnownHosts' => 'yes'
  }
}
```

4) User's ssh config is specified with an absolute path

```puppet
::ssh::client::config::user { 'riton':
  ensure => present,
  target => '/var/lib/riton/.ssh/ssh_config',
  options => {
    'HashKnownHosts' => 'yes'
  }
}
```

What is currently missing is the documentation for this new type.

Before writting it, I'd like to know your opinion about this new define type and its implementation.

_Note_: Don't care about the `.travis.yml` patch ... I'll revert if you're ready to accept this pull request.