### PR TITLE
Add parameter to manage ssh_known_hosts file

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,12 +1,15 @@
 class ssh::client(
   $ensure               = present,
   $storeconfigs_enabled = true,
+  $manage_ssh_known_hosts,
   $options              = {}
 ) inherits ssh::params {
   $merged_options = merge($ssh::params::ssh_default_options, $options)
 
   include ssh::client::install
-  include ssh::client::config
+  class { 'ssh::client::config':
+    manage_ssh_known_hosts => $manage_ssh_known_hosts,
+  }
 
   anchor { 'ssh::client::start': }
   anchor { 'ssh::client::end': }

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -1,4 +1,6 @@
-class ssh::client::config {
+class ssh::client::config (
+  $manage_ssh_known_hosts
+) {
   file { $ssh::params::ssh_config:
     ensure  => present,
     owner   => 0,
@@ -7,9 +9,11 @@ class ssh::client::config {
     require => Class['ssh::client::install'],
   }
 
-  # Workaround for http://projects.reductivelabs.com/issues/2014
-  file { $ssh::params::ssh_known_hosts:
-    ensure => present,
-    mode   => '0644',
+  if ($manage_ssh_known_hosts == true) {
+    # Workaround for http://projects.reductivelabs.com/issues/2014
+    file { $ssh::params::ssh_known_hosts:
+      ensure => present,
+      mode   => '0644',
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 class ssh (
-  $server_options       = {},
-  $client_options       = {},
-  $storeconfigs_enabled = true
+  $server_options         = {},
+  $client_options         = {},
+  $manage_ssh_known_hosts = true,
+  $storeconfigs_enabled   = true
 ) inherits ssh::params {
   class { 'ssh::server':
     storeconfigs_enabled => $storeconfigs_enabled,
@@ -9,7 +10,8 @@ class ssh (
   }
 
   class { 'ssh::client':
-    storeconfigs_enabled => $storeconfigs_enabled,
-    options              => $client_options,
+    storeconfigs_enabled   => $storeconfigs_enabled,
+    manage_ssh_known_hosts => $manage_ssh_known_hosts,
+    options                => $client_options,
   }
 }

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,7 +1,12 @@
 require 'spec_helper'
 
 describe 'ssh::client', :type => 'class' do
-    context "On Debian with no other parameters" do
+    context "On Debian with manage_ssh_known_hosts set to true" do
+        let :params do
+          {
+            :manage_ssh_known_hosts => true
+          }
+        end
         let :facts do
         {
             :osfamily => 'Debian',


### PR DESCRIPTION
Previously, this module used a file resource to manage the ssh_known_hosts
file to work around an old bug. Some organizations want to manage this file
through their own means and NOT have this module manage the resource. For those
cases, the parameter of $manage_ssh_known_hosts has been added as a boolean
value. If that value does NOT equal the default of true, that file will not
be managed by this module.