### PR TITLE
fix $sftp_server_path on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,7 +28,7 @@ class ssh::params {
       $ssh_config = '/etc/ssh/ssh_config'
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       $service_name = 'sshd'
-      $sftp_server_path = '/usr/lib/openssh/sftp-server'
+      $sftp_server_path = '/usr/libexec/sftp-server'
     }
     Archlinux: {
       $server_package_name = 'openssh'


### PR DESCRIPTION
This fixes the default configuration on FreeBSD to make sftp actually work.