### PR TITLE
added option to specify package version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,18 @@
 class ssh (
   $server_options       = {},
   $client_options       = {},
+  $version              = 'present',
   $storeconfigs_enabled = true
 ) inherits ssh::params {
   class { 'ssh::server':
     storeconfigs_enabled => $storeconfigs_enabled,
     options              => $server_options,
+    ensure               => $version,
   }
 
   class { 'ssh::client':
     storeconfigs_enabled => $storeconfigs_enabled,
     options              => $client_options,
+    ensure               => $version,
   }
 }


### PR DESCRIPTION
This will allow user to control what version of ssh is installed, and manage any ssh upgrades through Hiera if so required. It is not a breaking change as it will leave the current ensure => present by default if no version is specified.