### PR TITLE
fix ed25519 handling.

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -50,11 +50,4 @@ class ssh::hostkeys {
       ensure       => absent,
     }
   }
-  if $::sshed25519key {
-    @@sshkey { "${::fqdn}_ed25519":
-      host_aliases => $host_aliases,
-      type         => 'ssh-ed25519',
-      key          => $::sshed25519key,
-    }
-  }
 }


### PR DESCRIPTION
either when merging in my change, or other changes that
take care about ed25519 handling, it broke, running git checkout
I get:

Info: Loading facts
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Sshkey[galen.l00-bugdead-prods.de_ed25519] is already declared in file /etc/puppet/environments/production/modules/ssh/manifests/hostkeys.pp:42; cannot redeclare at /etc/puppet/environments/production/modules/ssh/manifests/hostkeys.pp:54 at /etc/puppet/environments/production/modules/ssh/manifests/hostkeys.pp:54:5 on node galen.l00-bugdead-prods.de
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run

removing the second hunk, fixes problem for me.