### PR TITLE
Add support for SLES 11 SP3

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -50,7 +50,7 @@ class ssh::params {
       $service_name = 'sshd.service'
       $sftp_server_path = '/usr/lib/ssh/sftp-server'
     }
-    Suse: {
+    'Suse': {
       $server_package_name = 'openssh'
       $client_package_name = 'openssh'
       $sshd_dir = '/etc/ssh'
@@ -58,11 +58,11 @@ class ssh::params {
       $ssh_config = '/etc/ssh/ssh_config'
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       case $::operatingsystem {
-        Sles: {
+        'Sles', 'SLES': {
           $service_name = 'sshd'
           $sftp_server_path = '/usr/lib64/ssh/sftp-server'
         }
-        OpenSuSE: {
+        'OpenSuSE': {
           $service_name = 'sshd'
           $sftp_server_path = '/usr/lib/ssh/sftp-server'
         }


### PR DESCRIPTION
match case on Sles and SLES in param.pp
Use single parentheses around cases for the Suse osfamily tree in param.pp

This makes it work for me on SLES11 SP3, puppet-3.7.3-1.7, facter-2.0.2-2.3
And doesn't break on OpenSuse 13.1, facter-1.7.2-2.4.1, puppet-3.7.3

I'm not 100% sure why I need the single parentheses around the case statements, but note I run
the future parser, so that one might enforcing it?

