### PR TITLE
Revert "Add explicit allow_virtual parameters"

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -2,8 +2,7 @@ class ssh::client::install {
   if $ssh::params::client_package_name {
     if !defined(Package[$ssh::params::client_package_name]) {
       package { $ssh::params::client_package_name:
-        ensure        => $ssh::client::ensure,
-        allow_virtual => false,
+        ensure => $ssh::client::ensure,
       }
     }
   }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -3,8 +3,7 @@ class ssh::server::install {
   if $ssh::params::server_package_name {
     if !defined(Package[$ssh::params::server_package_name]) {
       package { $ssh::params::server_package_name:
-        ensure        => $ssh::server::ensure,
-        allow_virtual => false,
+        ensure   => $ssh::server::ensure,
       }
     }
   }


### PR DESCRIPTION
This reverts commit f63ae3b0b15927625b06e7db093ac661743a9ecf.

`allow_virtual` parameter was added in Puppet 3.6.1. On Puppet version
before this version, this parameter cause a catalogue compilation fail
`Invalid parameter allow_virtual`.

Refs: https://tickets.puppetlabs.com/browse/PUP-2746

This parameter should not be managed inside this module, but on top side
or in puppet configuration file.

```puppet
# site.pp or assimilated
if versioncmp($::puppetversion,'3.6.1') >= 0 {
  $allow_virtual_packages = hiera('allow_virtual_packages',false)
  Package {
    allow_virtual => $allow_virtual_packages,
  }
}
```

Or in puppet.conf, in order to remove warnings

```puppet
# puppet.conf
[main]
disable_warnings=deprecations
```

Refs: https://docs.puppetlabs.com/references/latest/configuration.html#disablewarnings
