### PR TITLE
Prevent empty Port or ListenAddress config parameters

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -5,19 +5,19 @@ AddressFamily <%= addressfamily %>
 <%- end -%>
 <%- if port = options.delete('Port') -%>
 <%- if port.is_a?(Array) -%>
-<%- port.each do |p| -%>
+<%- port.reject{ |x| x.strip.empty? }.each do |p| -%>
 Port <%= p %>
 <%- end -%>
-<%- else -%>
+<%- elsif not port.strip.empty? -%>
 Port <%= port %>
 <%- end -%>
 <%- end -%>
 <%- if listen = options.delete('ListenAddress') -%>
 <%- if listen.is_a?(Array) -%>
-<%- listen.each do |l| -%>
+<%- listen.reject{ |x| x.strip.empty? }.each do |l| -%>
 ListenAddress <%= l %>
 <%- end -%>
-<%- else -%>
+<%- elsif not listen.strip.empty? -%>
 ListenAddress <%= listen %>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
In our environment we need to limit the IP adresses that SSH is listening to. We use hiera to configure the specific adresses for a given machine using something like this:

```
ssh::server::options:
 ListenAddress:
   - '%{::ipaddress_eth0}'
   - '%{::ipaddress_eth2}'
```

If one of the interfaces is removed from the machine configuration, then the `ListenAddress` array will contain an empty string. This leads to a `ListenAddress` option without any argument in the configuration file. The missing argument causes sshd to not start at all which inhibits remote logins.

I modified the config template to filter out empty strings for the `Port` and `ListenAddress` parameters.