### PR TITLE
Support for merging options hash using multi-level hierarchy in hiera

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -3,7 +3,16 @@ class ssh::client(
   $storeconfigs_enabled = true,
   $options              = {}
 ) inherits ssh::params {
-  $merged_options = merge($ssh::params::ssh_default_options, $options)
+
+  # Merge hashes from multiple layer of hierarchy in hiera
+  $hiera_options = hiera_hash("${module_name}::client::options", undef)
+
+  $fin_options = $hiera_options ? {
+    undef   => $options,
+    default => $hiera_options,
+  }
+
+  $merged_options = merge($ssh::params::ssh_default_options, $fin_options)
 
   include ssh::client::install
   include ssh::client::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,15 +4,30 @@ class ssh (
   $version              = 'present',
   $storeconfigs_enabled = true
 ) inherits ssh::params {
+
+  # Merge hashes from multiple layer of hierarchy in hiera
+  $hiera_server_options = hiera_hash("${module_name}::server_options", undef)
+  $hiera_client_options = hiera_hash("${module_name}::client_options", undef)
+
+  $fin_server_options = $hiera_server_options ? {
+    undef   => $server_options,
+    default => $hiera_server_options,
+  }
+
+  $fin_client_options = $hiera_client_options ? {
+    undef   => $server_options,
+    default => $hiera_client_options,
+  }
+
   class { 'ssh::server':
     storeconfigs_enabled => $storeconfigs_enabled,
-    options              => $server_options,
+    options              => $fin_server_options,
     ensure               => $version,
   }
 
   class { 'ssh::client':
     storeconfigs_enabled => $storeconfigs_enabled,
-    options              => $client_options,
+    options              => $fin_client_options,
     ensure               => $version,
   }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -3,7 +3,16 @@ class ssh::server(
   $storeconfigs_enabled = true,
   $options              = {}
 ) inherits ssh::params {
-  $merged_options = merge($ssh::params::sshd_default_options, $options)
+
+  # Merge hashes from multiple layer of hierarchy in hiera
+  $hiera_options = hiera_hash("${module_name}::server::options", undef)
+
+  $fin_options = $hiera_options ? {
+    undef   => $options,
+    default => $hiera_options,
+  }
+
+  $merged_options = merge($ssh::params::sshd_default_options, $fin_options)
 
   include ssh::server::install
   include ssh::server::config


### PR DESCRIPTION
First, let me thank you for this module. It's well written and easy to use.
I use automatic parameters lookup extensively. Let's say I have this (really) simple hierarchy :
```
# hiera.yaml
---
:backends:
 - yaml
:hierarchy:
 - "nodes/%{clientcert}"
 - "common"
```
I set some options in the common.yaml file which will be applied to every nodes and used as a base configuration :
```
# common.yaml
---
ssh::server_options:
 Port: '22'
 AddressFamily: 'inet'
 Protocol: '2'
 ListenAddress:
  - %{::ipaddress_eth0}
 PermitRootLogin: 'yes'
... etc
```
Now I want to override the PermitRootLogin parameter. I'd like to do it like this in my server1.yaml :
```
# server1.yaml
---
ssh::server_options:
 PermitRootLogin: 'without-password'
```
And ouch ! Problem here. Every parameters set in my base configuration get flushed out except for the PermitRootLogin parameter (and the default options set through your sshd_default_options hash). To make specific changes for a node, I need to copy/paste every default options set in common.yaml along with the specific params I want. This is like losing the interest of hiera which is to be able to override things in a simple manner.

This is due to Puppet's automatic params lookup which can only use the priority lookup type (https://docs.puppetlabs.com/hiera/1/puppet.html#limitations).

My patch tries to solve this using the hiera_hash function. This way you can only specify the parameter you want to override. The function will take care of merging all the hashes defined in each level of hierarchy.

To take the most of it I suggest to use the "deeper" merging behavior of hiera so that nested data structures (an array in a hash for example) will also be scanned (It's the case for the ListenAddress directive for example).

This is my first pull request on github by the way so if you find that I didn't follow some guidelines or best practice, don't hesitate to tell me.