### PR TITLE
fix unspecified ssh_config file permissions

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -3,6 +3,7 @@ class ssh::client::config {
     ensure  => present,
     owner   => '0',
     group   => '0',
+    mode    => '0644',
     content => template("${module_name}/ssh_config.erb"),
     require => Class['ssh::client::install'],
   }


### PR DESCRIPTION
Hi,

On my systems (rhel like), the ssh_config file comes with mode 644.
Strangely, puppet (3.7) changes that mode when it runs : 

Notice: /Stage[main]/Ssh::Client::Config/File[/etc/ssh/ssh_config]/mode: mode changed '0644' to '0640'

This is problematic for my hostbased ssh hosts, which then cannot read the ssh_config and almost silently fail hostbased connections.
This PR fixes that puppet strange behaviour (manual does not say a thing about default file mode...).