### PR TITLE
Corrected regression which applied server settings to the client configuration

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class ssh (
   }
 
   $fin_client_options = $hiera_client_options ? {
-    undef   => $server_options,
+    undef   => $client_options,
     default => $hiera_client_options,
   }
 


### PR DESCRIPTION
The last release (2.6) has a pretty bad bug which, if run, will prevent users from being able to SSH out of their host machines.

The problem is that the system is applying configuration meant for the server (sshd_config) to the client configuration (ssh_config). Since these values are not valid configurations this results in a broken system.