### PR TITLE
It's needed since due for a bug in puppet hiera_hash might return an …

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,6 +9,7 @@ class ssh::server(
 
   $fin_options = $hiera_options ? {
     undef   => $options,
+    ''      => $options,
     default => $hiera_options,
   }
 


### PR DESCRIPTION
…empty string instead of the default value.