### PR TITLE
Fix default client_options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class ssh (
   }
 
   $fin_client_options = $hiera_client_options ? {
-    undef   => $server_options,
+    undef   => $client_options,
     default => $hiera_client_options,
   }
 


### PR DESCRIPTION
There was a typo that if the parameters were passed directly into the class, not via Hiera, the client would be configured with server options and the client options would be ignored.