### PR TITLE
Fix ssh::client_options parameter being ignored.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@ class ssh (
   }
 
   $fin_client_options = $hiera_client_options ? {
-    undef   => $server_options,
+    undef   => $client_options,
     default => $hiera_client_options,
   }
 


### PR DESCRIPTION
Bug introduced by #102. If no `ssh::client_options` are specified in hiera then the `ssh::client` will be given the servers options for configuration. This can result in a broken SSH client configuration as the server options are not valid for the client.

To reproduce this you can have the following hiera configuration

``` yaml
---
ssh::server_options:
  PermitRootLogin: 'without-password'
```

and the `/etc/ssh/ssh_config` file will be filled with an invalid configuration. This issue can be worked around by adding a `ssh::client_options` section to hiera so that the `$hiera_client_options` are not undefined.
