### PR TITLE
Option to configure ssh via augeas ssh provider

### DIFF
--- a/lib/puppet/parser/functions/sshclient_options_to_augeas_ssh_config.rb
+++ b/lib/puppet/parser/functions/sshclient_options_to_augeas_ssh_config.rb
@@ -92,20 +92,15 @@ module Puppet::Parser::Functions
   options.each do |key1,value1|
     if value1.is_a?(Hash)
       value1.each do |key2,value2|
-        options_final_augeas["#{key2} #{key1.gsub("Host ","")}"] = { 'ensure' => 'present' }
-                      .merge({'host' => key1.gsub("Host ","")})
-                      .merge({'key' => key2, 'value' => value2})
-                      .merge(other_parameters)
+        v = { 'ensure' => 'present' }.merge({'host' => key1.gsub("Host ","")}).merge({'key' => key2, 'value' => value2})
+        options_final_augeas["#{key2} #{key1.gsub("Host ","")}"] = v.merge(other_parameters)
       end
     else
-      options_final_augeas[key1] = { 'ensure' => 'present' }
-                      .merge({'key' => key1, 'value' => value1})
-                      .merge(other_parameters)
+      options_final_augeas[key1] = { 'ensure' => 'present' }.merge({'key' => key1, 'value' => value1}).merge(other_parameters)
     end 
   end
   options_absent.each do |value| 
-    options_final_augeas[value] = { 'ensure' => 'absent' }.merge({'key' => value})
-                      .merge(other_parameters)
+    options_final_augeas[value] = { 'ensure' => 'absent' }.merge({'key' => value}).merge(other_parameters)
   end
   return options_final_augeas
 

--- a/lib/puppet/parser/functions/sshclient_options_to_augeas_ssh_config.rb
+++ b/lib/puppet/parser/functions/sshclient_options_to_augeas_ssh_config.rb
@@ -1,0 +1,113 @@
+module Puppet::Parser::Functions
+  newfunction(:sshclient_options_to_augeas_ssh_config, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+  This function will convert a key-value hash to a format understandable by the augeas sshd_config provider
+  It will also optionally deal with keys that should be absent, and inject static parameters if supplied.
+
+  Usage: sshclient_options_to_augeas_ssh_config($options_present, $options_absent, $other_parameters)
+  -  $options_hash is mandatory and must be a hash.
+  -  $options_absent is optional and can be either a single value or an array.
+  -  $other_parameters is optional and must be a hash.
+
+  Example:
+  $options = {
+                'Host *.example.com' => {
+                   'ForwardAgent' => 'yes',
+                   'BatchMode'    => 'yes',
+                },
+                'ForwardAgent'           => 'no',
+                'BatchMode'              => 'no',
+                'StrictHostKeyChecking'  => 'no',
+             }
+  $options_absent = ['StrictHostKeyChecking','NoneField']
+  $other_parameters = { 'target' => '/etc/ssh/ssh_config' }
+
+  $options_final_augeas = sshclient_options_to_augeas_ssh_config($options, $options_absent, $other_parameters)
+
+  In this case, the value of $options_final_augeas would be:
+ 
+  'ForwardAgent *.example.com' => {
+      'ensure'    => 'present',
+      'host'      => '*.example.com',
+      'key'       => 'ForwardAgent',
+      'value'     => 'yes',
+      'target'    => '/etc/ssh/ssh_config',
+   }
+  'BatchMode *.example.com' => {
+      'ensure'    => 'present',
+      'host'      => '*.example.com',
+      'key'       => 'BatchMode',
+      'value'     => 'yes',
+      'target'    => '/etc/ssh/ssh_config',
+   }
+  'ForwardAgent' => {
+      'ensure'    => 'present',
+      'key'       => 'ForwardAgent',
+      'value'     => 'yes',
+      'target'    => '/etc/ssh/ssh_config',
+   }
+  'BatchMode' => {
+      'ensure'    => 'present',
+      'key'       => 'BatchMode',
+      'value'     => 'yes',
+      'target'    => '/etc/ssh/ssh_config',
+   }
+  'StrictHostKeyChecking' => {
+      'ensure'    => 'absent',
+      'key'       => 'StrictHostKeyChecking',
+      'target'    => '/etc/ssh/ssh_config',
+   }
+   'NoneField' => {
+      'ensure'    => 'absent',
+      'key'       => 'NoneField',
+      'target'    => '/etc/ssh/ssh_config',
+   }
+
+  Note how the word "Host" is stripped away.
+
+  ENDHEREDOC
+
+  if args.length < 1
+     raise Puppet::ParseError,("sshclient_options_to_augeas_ssh_config: expects at least one argument")
+  end
+
+  options = args[0]
+  unless options.is_a?(Hash)
+    raise Puppet::ParseError,("sshclient_options_to_augeas_ssh_config: first argument must be a hash")
+  end
+
+  options_absent = args[1] if args[1]
+  other_parameters = args[2] if args[2]
+  if options_absent
+    unless options_absent.is_a?(Array) or options_absent.is_a?(String)
+      raise Puppet::ParseError,("sshclient_options_to_augeas_ssh_config: second argument, if supplied, must be an array or a string")
+    end
+  end
+  if other_parameters
+    unless other_parameters.is_a?(Hash)
+      raise Puppet::ParseError,("sshclient_options_to_augeas_ssh_config: third argument, if supplied, must be a hash")
+    end
+  end
+   
+  options_final_augeas = {} 
+  options.each do |key1,value1|
+    if value1.is_a?(Hash)
+      value1.each do |key2,value2|
+        options_final_augeas["#{key2} #{key1.gsub("Host ","")}"] = { 'ensure' => 'present' }
+                      .merge({'host' => key1.gsub("Host ","")})
+                      .merge({'key' => key2, 'value' => value2})
+                      .merge(other_parameters)
+      end
+    else
+      options_final_augeas[key1] = { 'ensure' => 'present' }
+                      .merge({'key' => key1, 'value' => value1})
+                      .merge(other_parameters)
+    end 
+  end
+  options_absent.each do |value| 
+    options_final_augeas[value] = { 'ensure' => 'absent' }.merge({'key' => value})
+                      .merge(other_parameters)
+  end
+  return options_final_augeas
+
+  end #newfunction
+end #module

--- a/lib/puppet/parser/functions/sshserver_options_to_augeas_sshd_config.rb
+++ b/lib/puppet/parser/functions/sshserver_options_to_augeas_sshd_config.rb
@@ -102,20 +102,15 @@ module Puppet::Parser::Functions
   options.each do |key1,value1|
     if value1.is_a?(Hash)
       value1.each do |key2,value2|
-        options_final_augeas["#{key2} #{key1.gsub("Match ","")}"] = { 'ensure' => 'present' }
-                      .merge({'condition' => key1.gsub("Match ","")})
-                      .merge({'key' => key2, 'value' => value2})
-                      .merge(other_parameters)
+        v = { 'ensure' => 'present' }.merge({'condition' => key1.gsub("Match ","")}).merge({'key' => key2, 'value' => value2})
+        options_final_augeas["#{key2} #{key1.gsub("Match ","")}"] = v.merge(other_parameters)
       end
     else
-      options_final_augeas[key1] = { 'ensure' => 'present' }
-                      .merge({'key' => key1, 'value' => value1})
-                      .merge(other_parameters)
+      options_final_augeas[key1] = { 'ensure' => 'present' }.merge({'key' => key1, 'value' => value1}).merge(other_parameters)
     end 
   end
   options_absent.each do |value| 
-    options_final_augeas[value] = { 'ensure' => 'absent' }.merge({'key' => value})
-                      .merge(other_parameters)
+    options_final_augeas[value] = { 'ensure' => 'absent' }.merge({'key' => value}).merge(other_parameters)
   end
   return options_final_augeas
 

--- a/lib/puppet/parser/functions/sshserver_options_to_augeas_sshd_config.rb
+++ b/lib/puppet/parser/functions/sshserver_options_to_augeas_sshd_config.rb
@@ -1,0 +1,123 @@
+module Puppet::Parser::Functions
+  newfunction(:sshserver_options_to_augeas_sshd_config, :type => :rvalue, :doc => <<-'ENDHEREDOC') do |args|
+  This function will convert a key-value hash to a format understandable by the augeas sshd_config provider
+  It will also optionally deal with keys that should be absent, and inject static parameters if supplied.
+
+  Usage: sshserver_options_to_augeas_sshd_config($options_present, $options_absent, $other_parameters)
+  -  $options_hash is mandatory and must be a hash.
+  -  $options_absent is optional and can be either a single value or an array.
+  -  $other_parameters is optional and must be a hash.
+
+  Example:
+  $options = {
+                'Match User www-data' => {
+                   'PasswordAuthentication' => 'yes',
+                   'X11Forwarding' => 'no',
+                },
+                'Match Group bamboo' => {
+                   'ForcedCommand'  => '/bin/echo hello world',
+                },
+                'X11Forwarding'          => 'yes',
+                'DebianBanner'           => '/etc/banner.net',
+                'AllowGroups'            => ["sshgroups", "admins"],
+             }
+  $options_absent = ['DebianBanner','NoneField']
+  $other_parameters = { 'target' => '/etc/ssh/sshd_config' }
+
+  $options_final_augeas = sshserver_options_to_augeas_sshd_config($options, $options_absent, $other_parameters)
+
+  In this case, the value of $options_final_augeas would be:
+ 
+  'PasswordAuthentication User www-data' => {
+      'ensure'    => 'present',
+      'condition' => 'User www-data',
+      'key'       => 'PasswordAuthentication',
+      'value'     => 'yes',
+      'target'    => '/etc/ssh/sshd_config',
+   }
+   'X11Forwarding User www-data' => {
+      'ensure'    => 'present',
+      'condition' => 'User www-data',
+      'key'       => 'X11Forwarding',
+      'value'     => 'no',
+      'target'    => '/etc/ssh/sshd_config',
+   }
+   'ForcedCommand Group bamboo' => {
+      'ensure'    => 'present',
+      'condition' => 'Group bamboo',
+      'key'       => 'ForcedCommand',
+      'value'     => '/bin/echo hello world',
+      'target'    => '/etc/ssh/sshd_config',
+   }
+   'X11Forwarding' => {
+      'ensure'    => 'present',
+      'key'       => 'X11Forwarding',
+      'value'     => 'yes',
+      'target'    => '/etc/ssh/sshd_config',
+   }
+   'DebianBanner' => {
+      'ensure'    => 'absent',
+      'key'       => 'DebianBanner',
+      'target'    => '/etc/ssh/sshd_config',
+   }
+   'AllowGroups' => {
+      'ensure'    => 'present',
+      'key'       => 'AllowGroups',
+      'value'     => ['sshgroups','admins'],
+      'target'    => '/etc/ssh/sshd_config',
+   }
+   'NoneField' => {
+      'ensure'    => 'absent',
+      'key'       => 'NoneField',
+      'target'    => '/etc/ssh/sshd_config',
+   }
+
+  Note how the word "Match" is stripped away.
+
+  ENDHEREDOC
+
+  if args.length < 1
+     raise Puppet::ParseError,("sshserver_options_to_augeas_sshd_config: expects at least one argument")
+  end
+
+  options = args[0]
+  unless options.is_a?(Hash)
+    raise Puppet::ParseError,("sshserver_options_to_augeas_sshd_config: first argument must be a hash")
+  end
+
+  options_absent = args[1] if args[1]
+  other_parameters = args[2] if args[2]
+  if options_absent
+    unless options_absent.is_a?(Array) or options_absent.is_a?(String)
+      raise Puppet::ParseError,("sshserver_options_to_augeas_sshd_config: second argument, if supplied, must be an array or a string")
+    end
+  end
+  if other_parameters
+    unless other_parameters.is_a?(Hash)
+      raise Puppet::ParseError,("sshserver_options_to_augeas_sshd_config: third argument, if supplied, must be a hash")
+    end
+  end
+   
+  options_final_augeas = {} 
+  options.each do |key1,value1|
+    if value1.is_a?(Hash)
+      value1.each do |key2,value2|
+        options_final_augeas["#{key2} #{key1.gsub("Match ","")}"] = { 'ensure' => 'present' }
+                      .merge({'condition' => key1.gsub("Match ","")})
+                      .merge({'key' => key2, 'value' => value2})
+                      .merge(other_parameters)
+      end
+    else
+      options_final_augeas[key1] = { 'ensure' => 'present' }
+                      .merge({'key' => key1, 'value' => value1})
+                      .merge(other_parameters)
+    end 
+  end
+  options_absent.each do |value| 
+    options_final_augeas[value] = { 'ensure' => 'absent' }.merge({'key' => value})
+                      .merge(other_parameters)
+  end
+  return options_final_augeas
+
+  end #newfunction
+end #module

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,7 +1,9 @@
 class ssh::client(
   $ensure               = present,
   $storeconfigs_enabled = true,
-  $options              = {}
+  $options              = {},
+  $use_augeas           = false,
+  $options_absent       = [],
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera
@@ -9,10 +11,15 @@ class ssh::client(
 
   $fin_options = $hiera_options ? {
     undef   => $options,
+    ''      => $options,
     default => $hiera_options,
   }
 
-  $merged_options = merge($ssh::params::ssh_default_options, $fin_options)
+  if $use_augeas {
+    $merged_options = sshclient_options_to_augeas_ssh_config($fin_options, $options_absent, { 'target' => $::ssh::params::ssh_config })
+  } else {
+    $merged_options = merge($ssh::params::ssh_default_options, $fin_options)
+  }
 
   include ssh::client::install
   include ssh::client::config

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -1,14 +1,21 @@
 class ssh::client::config
 {
   $options = $::ssh::client::merged_options
+  $use_augeas = $::ssh::client::use_augeas
 
-  file { $ssh::params::ssh_config:
-    ensure  => present,
-    owner   => '0',
-    group   => '0',
-    mode    => '0644',
-    content => template("${module_name}/ssh_config.erb"),
-    require => Class['ssh::client::install'],
+  if $use_augeas {
+
+    create_resources('ssh_config', $options)
+
+  } else {
+    file { $ssh::params::ssh_config:
+      ensure  => present,
+      owner   => '0',
+      group   => '0',
+      mode    => '0644',
+      content => template("${module_name}/ssh_config.erb"),
+      require => Class['ssh::client::install'],
+    }
   }
 
   # Workaround for http://projects.reductivelabs.com/issues/2014

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,15 +1,20 @@
 class ssh (
-  $server_options       = {},
-  $client_options       = {},
-  $users_client_options = {},
-  $version              = 'present',
-  $storeconfigs_enabled = true
+  $server_options        = {},
+  $client_options        = {},
+  $users_client_options  = {},
+  $version               = 'present',
+  $storeconfigs_enabled  = true,
+  $use_augeas            = false,
+  $server_options_absent = [],
+  $client_options_absent = [],
 ) inherits ssh::params {
 
   validate_hash($server_options)
   validate_hash($client_options)
   validate_hash($users_client_options)
   validate_bool($storeconfigs_enabled)
+  validate_bool($use_augeas)
+  validate_array($server_options_absent)
 
   # Merge hashes from multiple layer of hierarchy in hiera
   $hiera_server_options = hiera_hash("${module_name}::server_options", undef)
@@ -35,12 +40,16 @@ class ssh (
     ensure               => $version,
     storeconfigs_enabled => $storeconfigs_enabled,
     options              => $fin_server_options,
+    use_augeas           => $use_augeas,
+    options_absent       => $server_options_absent,
   }
 
   class { 'ssh::client':
     ensure               => $version,
     storeconfigs_enabled => $storeconfigs_enabled,
     options              => $fin_client_options,
+    use_augeas           => $use_augeas,
+    options_absent       => $client_options_absent,
   }
 
   create_resources('::ssh::client::config::user', $fin_users_client_options)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,7 +1,9 @@
 class ssh::server(
   $ensure               = present,
   $storeconfigs_enabled = true,
-  $options              = {}
+  $options              = {},
+  $use_augeas           = false,
+  $options_absent       = [],
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera
@@ -13,7 +15,11 @@ class ssh::server(
     default => $hiera_options,
   }
 
-  $merged_options = merge($ssh::params::sshd_default_options, $fin_options)
+  if $use_augeas {
+    $merged_options = sshserver_options_to_augeas_sshd_config($fin_options, $options_absent, { 'target' => $::ssh::params::sshd_config })
+  } else {
+    $merged_options = merge($ssh::params::sshd_default_options, $fin_options)
+  }
 
   include ssh::server::install
   include ssh::server::config

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,16 +1,24 @@
 class ssh::server::config {
+  $options = $::ssh::server::merged_options
+  $use_augeas = $::ssh::server::use_augeas
 
-  concat { $ssh::params::sshd_config:
-    ensure => present,
-    owner  => '0',
-    group  => '0',
-    mode   => '0600',
-    notify => Service[$ssh::params::service_name]
-  }
+  if $use_augeas {
 
-  concat::fragment { 'global config':
-    target  => $ssh::params::sshd_config,
-    content => template("${module_name}/sshd_config.erb"),
-    order   => '00'
+    create_resources('sshd_config', $options)
+
+  } else {
+    concat { $ssh::params::sshd_config:
+      ensure => present,
+      owner  => '0',
+      group  => '0',
+      mode   => '0600',
+      notify => Service[$ssh::params::service_name]
+    }
+
+    concat::fragment { 'global config':
+      target  => $ssh::params::sshd_config,
+      content => template("${module_name}/sshd_config.erb"),
+      order   => '00'
+    }
   }
 }

--- a/manifests/server/match_block.pp
+++ b/manifests/server/match_block.pp
@@ -1,7 +1,7 @@
 define ssh::server::match_block ($options, $type = 'user', $order = 50,) {
 
   if $::ssh::server::use_augeas {
-    fail("ssh::server::match_block() define not supported with use_augeas = true")
+    fail('ssh::server::match_block() define not supported with use_augeas = true')
   } else {
     concat::fragment { "match_block ${name}":
       target  => $ssh::params::sshd_config,

--- a/manifests/server/match_block.pp
+++ b/manifests/server/match_block.pp
@@ -1,7 +1,12 @@
 define ssh::server::match_block ($options, $type = 'user', $order = 50,) {
-  concat::fragment { "match_block ${name}":
-    target  => $ssh::params::sshd_config,
-    content => template("${module_name}/sshd_match_block.erb"),
-    order   => $order,
+
+  if $::ssh::server::use_augeas {
+    fail("ssh::server::match_block() define not supported with use_augeas = true")
+  } else {
+    concat::fragment { "match_block ${name}":
+      target  => $ssh::params::sshd_config,
+      content => template("${module_name}/sshd_match_block.erb"),
+      order   => $order,
+    }
   }
 }


### PR DESCRIPTION
This is a fantastic module, and I've used it for years. I love the way I can specify options as a simple key-value hash. The downside of using this module is that it will completely replace the /etc/ssh/sshd_config file, which means we really need to make sure we know what we're doing because there's a real danger of breaking sshd and losing remote access.

The other approach is to use the augeas-based ssh provider, which allows us to only manage those settings we want to manage, leaving all other settings untouched (and not assuming any default values). This is safer than a template-based approach, but the downside is that the data model of specifying options is a real pain to work with.

This feature enhancement blends the best of both worlds by adding a "use_augeas" option to the ssh, ssh::server and ssh::client classes, which means it becomes possible to use this module to manage specific options only via the augeas provider, and leave unspecified options untouched. Best of all, users can continue to specify options using the same simple key-value hash as before.
