### PR TITLE
Allow segregation of groups for hostkeys

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -1,6 +1,8 @@
-class ssh::hostkeys {
+class ssh::hostkeys ($storeconfigs_group = undef) {
   $ipaddresses = ipaddresses()
   $host_aliases = flatten([ $::fqdn, $::hostname, $ipaddresses ])
+
+  tag 'hostkey_all', "hostkey_${storeconfigs_group}"
 
   if $::sshdsakey {
     @@sshkey { "${::fqdn}_dsa":

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -1,5 +1,3 @@
 class ssh::knownhosts ($storeconfigs_group = undef) {
-  Sshkey <<| tag == "hostkey_${storeconfigs_group}" |>> {
-    ensure => present,
-  }
+  Sshkey <<| tag == "hostkey_${storeconfigs_group}" |>>
 }

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -1,3 +1,5 @@
-class ssh::knownhosts {
-  Sshkey <<| |>>
+class ssh::knownhosts ($storeconfigs_group = undef) {
+  Sshkey <<| tag == "hostkey_${storeconfigs_group}" |>> {
+    ensure => present,
+  }
 }


### PR DESCRIPTION
This small addition allows grouping hosts so that not all hostkeys are distributed to every host but only to hosts belonging to a group of hosts.
