### PR TITLE
Work around Puppet future parser bug.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class ssh (
 
   $fin_users_client_options = $hiera_users_client_options ? {
     undef   => $users_client_options,
+    ''      => $users_client_options,
     default => $hiera_users_client_options,
   }
 


### PR DESCRIPTION
On Puppet 3.7.4 with the future parser enabled, `undef` values are converted to empty strings, which evaluate as true. This means when there are no user client options specified in Hiera, `$fin_users_client_options` gets passed to `create_resources` as an empty string, which is invalid.

Work around this Puppet bug by setting default options when `$hiera_users_client_options` is an empty string.

Fixes #124 