### PR TITLE
Fix exitcode for fact to prevent failure using Facter 3.x

### DIFF
--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,6 +1,6 @@
 Facter.add("ssh_client_version_full") do
   setcode do
-    version = Facter::Util::Resolution.exec('sshd -V 2>&1').
+    version = Facter::Util::Resolution.exec('sshd -V 2>&1 || true').
       lines.
       to_a.
       select { |line| line.match(/^OpenSSH_/) }.

--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -3,7 +3,7 @@ Facter.add("ssh_server_version_full") do
     # sshd doesn't actually have a -V option (hopefully one will be added),
     # by happy coincidence the usage information that is printed includes the
     # version number.
-    version = Facter::Util::Resolution.exec('sshd -V 2>&1').
+    version = Facter::Util::Resolution.exec('sshd -V 2>&1 || true').
       lines.
       to_a.
       select { |line| line.match(/^OpenSSH_/) }.


### PR DESCRIPTION
Facter 3.x seems to be more picky about the exit code when running external commands. The current code fails to run as the method returns nil to indicate that the command exited with an error code:

```
Error: Facter: error while resolving custom fact "ssh_server_version_full": undefined method `lines' for nil:NilClass
Error: Facter: error while resolving custom fact "ssh_server_version_major": undefined method `gsub' for nil:NilClass
Error: Facter: error while resolving custom fact "ssh_server_version_release": undefined method `gsub' for nil:NilClass
```

The patch is an easy fix to prevent that the sshd failure code reaches the Facter code.

Maybe using something like `sshd -d -t` is a better alternative in the long run?