### PR TITLE
Make collecting and filling known_hosts optional

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,6 +1,7 @@
 class ssh::client(
   $ensure               = present,
   $storeconfigs_enabled = true,
+  $collect_enabled      = true,
   $options              = {}
 ) inherits ssh::params {
 
@@ -23,7 +24,9 @@ class ssh::client(
   # Provide option to *not* use storeconfigs/puppetdb, which means not managing
   #  hostkeys and knownhosts
   if ($storeconfigs_enabled) {
-    include ssh::knownhosts
+    class { 'ssh::knownhosts': 
+      collect_enabled => $collect_enabled
+    }
 
     Anchor['ssh::client::start'] ->
     Class['ssh::client::install'] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,13 +3,15 @@ class ssh (
   $client_options       = {},
   $users_client_options = {},
   $version              = 'present',
-  $storeconfigs_enabled = true
+  $storeconfigs_enabled = true,
+  $collect_enabled      = true
 ) inherits ssh::params {
 
   validate_hash($server_options)
   validate_hash($client_options)
   validate_hash($users_client_options)
   validate_bool($storeconfigs_enabled)
+  validate_bool($collect_enabled)
 
   # Merge hashes from multiple layer of hierarchy in hiera
   $hiera_server_options = hiera_hash("${module_name}::server_options", undef)
@@ -34,12 +36,14 @@ class ssh (
   class { 'ssh::server':
     ensure               => $version,
     storeconfigs_enabled => $storeconfigs_enabled,
+    collect_enabled      => $collect_enabled,
     options              => $fin_server_options,
   }
 
   class { 'ssh::client':
     ensure               => $version,
     storeconfigs_enabled => $storeconfigs_enabled,
+    collect_enabled      => $collect_enabled,
     options              => $fin_client_options,
   }
 

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -1,3 +1,7 @@
-class ssh::knownhosts {
-  Sshkey <<| |>>
+class ssh::knownhosts(
+  $collect_enabled = true
+) {
+  if ($collect_enabled) {
+    Sshkey <<| |>>
+  }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,6 +1,7 @@
 class ssh::server(
   $ensure               = present,
   $storeconfigs_enabled = true,
+  $collect_enabled      = true,
   $options              = {}
 ) inherits ssh::params {
 
@@ -26,7 +27,9 @@ class ssh::server(
   #  hostkeys and knownhosts
   if ($storeconfigs_enabled) {
     include ssh::hostkeys
-    include ssh::knownhosts
+    class { 'ssh::knownhosts': 
+      collect_enabled => $collect_enabled
+    }
 
     Anchor['ssh::server::start'] ->
     Class['ssh::server::install'] ->


### PR DESCRIPTION
I like to be able to not collect (all of) the ssh keys on the hosts that
I export the keys on, making exporting and collecting separately configurable.

Add a parameter collect_enabled to make collecting the exported
ssh keys optional in ssh::server and ssh::client. Defaults to true (like
storeconfigs_enabled).