### PR TITLE
Create Hook For Managing SSH Server Service

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,12 +1,15 @@
-class ssh::server::service {
+class ssh::server::service (
+  $ensure = 'running',
+  $enable = 'true'
+){
   include ssh::params
   include ssh::server
 
   service { $ssh::params::service_name:
-    ensure     => running,
+    ensure     => $ssh::server::service::ensure,
     hasstatus  => true,
     hasrestart => true,
-    enable     => true,
+    enable     => $ssh::server::service::enable,
     require    => Class['ssh::server::config'],
   }
 }


### PR DESCRIPTION
As a sysadmin, I need to be able to turn the ssh server service off on some systems. These changes allow me to do this in my node manifest files or using my hiera data. 

## How To Use
In hiera, set `$ssh::server::service::enable = 'stopped'` to have puppet stop the ssh service. Set it back to `running` to turn it back on.