### PR TITLE
Enable hiera for ssh::server::match_block; fix hostkeys type errors

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -81,6 +81,13 @@ ssh::server_options:
     UsePAM: 'yes'
     X11Forwarding: 'yes'
 
+ssh::server_match_block:
+  filetransfer:
+    type: group
+    options:
+      ChrootDirectory: /home/sftp
+      ForceCommand: internal-sftp
+
 ssh::client_options:
     'Host *':
         SendEnv: 'LANG LC_*'

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -1,5 +1,6 @@
+# Class ssh::hostkeys
 class ssh::hostkeys {
-  $ipaddresses = ipaddresses()
+  $ipaddresses  = ipaddresses()
   $host_aliases = flatten([ $::fqdn, $::hostname, $ipaddresses ])
 
   if $::sshdsakey {
@@ -11,7 +12,7 @@ class ssh::hostkeys {
     }
   } else {
     @@sshkey { "${::fqdn}_dsa":
-      ensure       => absent,
+      ensure => absent,
     }
   }
   if $::sshrsakey {
@@ -23,7 +24,7 @@ class ssh::hostkeys {
     }
   } else {
     @@sshkey { "${::fqdn}_rsa":
-      ensure       => absent,
+      ensure => absent,
     }
   }
   if $::sshecdsakey {
@@ -35,7 +36,8 @@ class ssh::hostkeys {
     }
   } else {
     @@sshkey { "${::fqdn}_ecdsa":
-      ensure       => absent,
+      ensure => absent,
+      type   => 'ecdsa-sha2-nistp256',
     }
   }
   if $::sshed25519key {
@@ -47,7 +49,8 @@ class ssh::hostkeys {
     }
   } else {
     @@sshkey { "${::fqdn}_ed25519":
-      ensure       => absent,
+      ensure => absent,
+      type   => 'ed25519',
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,7 @@
+# Main file for puppet-ssh
 class ssh (
   $server_options       = {},
+  $server_match_block   = {},
   $client_options       = {},
   $users_client_options = {},
   $version              = 'present',
@@ -7,18 +9,25 @@ class ssh (
 ) inherits ssh::params {
 
   validate_hash($server_options)
+  validate_hash($server_match_block)
   validate_hash($client_options)
   validate_hash($users_client_options)
   validate_bool($storeconfigs_enabled)
 
   # Merge hashes from multiple layer of hierarchy in hiera
   $hiera_server_options = hiera_hash("${module_name}::server_options", undef)
+  $hiera_server_match_block = hiera_hash("${module_name}::server_match_block", undef)
   $hiera_client_options = hiera_hash("${module_name}::client_options", undef)
   $hiera_users_client_options = hiera_hash("${module_name}::users_client_options", undef)
 
   $fin_server_options = $hiera_server_options ? {
     undef   => $server_options,
     default => $hiera_server_options,
+  }
+
+  $fin_server_match_block = $hiera_server_match_block ? {
+    undef   => $server_match_block,
+    default => $hiera_server_match_block,
   }
 
   $fin_client_options = $hiera_client_options ? {
@@ -44,4 +53,5 @@ class ssh (
   }
 
   create_resources('::ssh::client::config::user', $fin_users_client_options)
+  create_resources('::ssh::server::match_block', $fin_server_match_block)
 }


### PR DESCRIPTION
Allow setting ssh::server::match_block from hiera and update README.markdown; add type to absent hostkeys resources to fix upgrade errors