### PR TITLE
check for nil version string

### DIFF
--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,13 +1,16 @@
 Facter.add("ssh_client_version_full") do
   setcode do
-    version = Facter::Util::Resolution.exec('sshd -V 2>&1').
-      lines.
-      to_a.
-      select { |line| line.match(/^OpenSSH_/) }.
-      first.
-      rstrip
+    version = Facter::Util::Resolution.exec('sshd -V 2>&1')
+    if version != nil
+      version.
+        lines.
+        to_a.
+        select { |line| line.match(/^OpenSSH_/) }.
+        first.
+        rstrip
 
-    version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+      version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+    end
   end
 end
 
@@ -15,7 +18,9 @@ Facter.add("ssh_client_version_major") do
   setcode do
     version = Facter.value('ssh_client_version_full')
 
-    version.gsub(/^([0-9]+\.[0-9]+).*$/, '\1')
+    if version != nil
+      version.gsub(/^([0-9]+\.[0-9]+).*$/, '\1')
+    end
   end
 end
 
@@ -23,6 +28,8 @@ Facter.add("ssh_client_version_release") do
   setcode do
     version = Facter.value('ssh_client_version_full')
 
-    version.gsub(/^([0-9]+\.[0-9]+(?:\.[0-9]+)?).*$/, '\1')
+    if version != nil
+      version.gsub(/^([0-9]+\.[0-9]+(?:\.[0-9]+)?).*$/, '\1')
+    end
   end
 end

--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -3,14 +3,17 @@ Facter.add("ssh_server_version_full") do
     # sshd doesn't actually have a -V option (hopefully one will be added),
     # by happy coincidence the usage information that is printed includes the
     # version number.
-    version = Facter::Util::Resolution.exec('sshd -V 2>&1').
-      lines.
-      to_a.
-      select { |line| line.match(/^OpenSSH_/) }.
-      first.
-      rstrip
+    version = Facter::Util::Resolution.exec('sshd -V 2>&1')
+    if version != nil
+      version.
+        lines.
+        to_a.
+        select { |line| line.match(/^OpenSSH_/) }.
+        first.
+        rstrip
 
-    version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+      version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+    end
   end
 end
 
@@ -18,7 +21,9 @@ Facter.add("ssh_server_version_major") do
   setcode do
     version = Facter.value('ssh_server_version_full')
 
-    version.gsub(/^([0-9]+\.[0-9]+).*$/, '\1')
+    if version != nil
+      version.gsub(/^([0-9]+\.[0-9]+).*$/, '\1')
+    end
   end
 end
 
@@ -26,6 +31,8 @@ Facter.add("ssh_server_version_release") do
   setcode do
     version = Facter.value('ssh_server_version_full')
 
-    version.gsub(/^([0-9]+\.[0-9]+(?:\.[0-9]+)?).*$/, '\1')
+    if version != nil
+      version.gsub(/^([0-9]+\.[0-9]+(?:\.[0-9]+)?).*$/, '\1')
+    end
   end
 end


### PR DESCRIPTION
If this module is used in an environment that contains Windows nodes, they
all result in throwing an error for each of these facts. Check to
make sure that `version` isn't `nil` prior to performing operations that
are only valid for a string.

Ideally it would have been nice to provide an inverse to `confine` but I don't know if that's possible.