### PR TITLE
added Solaris support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,6 +71,30 @@ class ssh::params {
         }
       }
     }
+    solaris: {
+      $sshd_dir = '/etc/ssh'
+      $sshd_config = '/etc/ssh/sshd_config'
+      $ssh_config = '/etc/ssh/ssh_config'
+      $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
+      $service_name = 'svc:/network/ssh:default'
+      $sftp_server_path = 'internal-sftp'
+      case versioncmp($::kernelrelease, '5.10') {
+        1: {
+          # Solaris 11 and later
+          $server_package_name = '/service/network/ssh'
+          $client_package_name = '/network/ssh'
+        }
+        0: {
+          # Solaris 10
+          $server_package_name = 'SUNWsshdu'
+          $client_package_name = 'SUNWsshu'
+        }
+        default: {
+          # Solaris 9 and earlier not supported
+          fail("Unsupported platform: ${::osfamily}/${::kernelrelease}")
+        }
+      }
+    }
     default: {
       case $::operatingsystem {
         gentoo: {
@@ -100,8 +124,9 @@ class ssh::params {
     }
   }
 
-  # OpenBSDs openssh doesn't link against PAM, therefore
-  # it doesn't know about the UsePAM option
+  # ssh & sshd default options:
+  # - OpenBSD doesn't know about UsePAM
+  # - Sun_SSH doesn't know about UsePAM & AcceptEnv; SendEnv & HashKnownHosts
   case $::osfamily {
     openbsd: {
       $sshd_default_options = {
@@ -111,6 +136,25 @@ class ssh::params {
         'AcceptEnv'                       => 'LANG LC_*',
         'Subsystem'                       => "sftp ${sftp_server_path}",
       }
+      $ssh_default_options = {
+        'Host *'                 => {
+          'SendEnv'              => 'LANG LC_*',
+          'HashKnownHosts'       => 'yes',
+        },
+      }
+    }
+    solaris: {
+      $sshd_default_options = {
+        'ChallengeResponseAuthentication' => 'no',
+        'X11Forwarding'                   => 'yes',
+        'PrintMotd'                       => 'no',
+        'Subsystem'                       => "sftp ${sftp_server_path}",
+        'HostKey'                         => [
+          "${sshd_dir}/ssh_host_rsa_key",
+          "${sshd_dir}/ssh_host_dsa_key",
+        ],
+      }
+      $ssh_default_options = { }
     }
     default: {
       $sshd_default_options = {
@@ -121,15 +165,13 @@ class ssh::params {
         'Subsystem'                       => "sftp ${sftp_server_path}",
         'UsePAM'                          => 'yes',
       }
-
+      $ssh_default_options = {
+        'Host *'                 => {
+          'SendEnv'              => 'LANG LC_*',
+          'HashKnownHosts'       => 'yes',
+        },
+      }
     }
-  }
-
-  $ssh_default_options = {
-    'Host *'                 => {
-      'SendEnv'              => 'LANG LC_*',
-      'HashKnownHosts'       => 'yes',
-    },
   }
 
   $user_ssh_directory_default_mode = '0700'


### PR DESCRIPTION
Solaris Secure Shell (aka Sun_SSH) is a fork of OpenSSH.  A few of the default
options are not compatible ... so I followed what was done for OpenBSD.  If
more platform exceptions come along then perhaps sshd_default_options /
ssh_default_options should be part of the earlier case statement ... or
abstracted away elsewhere.

Note: the OpenSSH facts shipped with v2.8.1 are broken and noisy on Solaris.
There are already a number of issues / pull requests related to these
facts not working on non-linux platforms ... so I didn't fix them as part of
this pull request.