### PR TITLE
Add check for sshd command in facts

### DIFF
--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,17 +1,22 @@
 Facter.add("ssh_client_version_full") do
-  setcode do
+  if File.exists?('/usr/sbin/sshd')
     version = Facter::Util::Resolution.exec('sshd -V 2>&1').
       lines.
       to_a.
       select { |line| line.match(/^OpenSSH_/) }.
       first.
       rstrip
+  end
 
-    version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+  setcode do
+    if not version.nil?
+      version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+    end
   end
 end
 
 Facter.add("ssh_client_version_major") do
+  confine :ssh_client_version_full => true
   setcode do
     version = Facter.value('ssh_client_version_full')
 
@@ -20,6 +25,7 @@ Facter.add("ssh_client_version_major") do
 end
 
 Facter.add("ssh_client_version_release") do
+  confine :ssh_client_version_full => true
   setcode do
     version = Facter.value('ssh_client_version_full')
 

--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -1,5 +1,5 @@
 Facter.add("ssh_server_version_full") do
-  setcode do
+  if File.exists?('/usr/sbin/sshd')
     # sshd doesn't actually have a -V option (hopefully one will be added),
     # by happy coincidence the usage information that is printed includes the
     # version number.
@@ -9,12 +9,17 @@ Facter.add("ssh_server_version_full") do
       select { |line| line.match(/^OpenSSH_/) }.
       first.
       rstrip
+  end
 
-    version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+  setcode do
+    if not version.nil?
+      version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+    end
   end
 end
 
 Facter.add("ssh_server_version_major") do
+  confine :ssh_server_version_full => true
   setcode do
     version = Facter.value('ssh_server_version_full')
 
@@ -23,6 +28,7 @@ Facter.add("ssh_server_version_major") do
 end
 
 Facter.add("ssh_server_version_release") do
+  confine :ssh_server_version_full => true
   setcode do
     version = Facter.value('ssh_server_version_full')
 


### PR DESCRIPTION
We can use this module in some env (for example, docker) which
doesn't have openssh-server package installed. As the result the following error occurred:

```
   Could not retrieve ssh_client_version_full: undefined method `lines' for nil:NilClass
   Could not retrieve ssh_client_version_full: undefined method `lines' for nil:NilClass
   Could not retrieve ssh_client_version_full: undefined method `lines' for nil:NilClass
   Could not retrieve ssh_client_version_full: undefined method `lines' for nil:NilClass
   Could not retrieve ssh_client_version_major: undefined method `gsub' for nil:NilClass
   ...

```
So we need to have some basic check for sshd command