### PR TITLE
fix params case statements for puppet4; make actual regexes, and case-insensitive

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class ssh::params {
   case $::osfamily {
-    debian: {
+    /(?i:debian)/: {
       $server_package_name = 'openssh-server'
       $client_package_name = 'openssh-client'
       $sshd_dir = '/etc/ssh'
@@ -10,7 +10,7 @@ class ssh::params {
       $service_name = 'ssh'
       $sftp_server_path = '/usr/lib/openssh/sftp-server'
     }
-    redhat: {
+    /(?i:redhat)/: {
       $server_package_name = 'openssh-server'
       $client_package_name = 'openssh-clients'
       $sshd_dir = '/etc/ssh'
@@ -20,7 +20,7 @@ class ssh::params {
       $service_name = 'sshd'
       $sftp_server_path = '/usr/libexec/openssh/sftp-server'
     }
-    freebsd: {
+    /(?i:freebsd)/: {
       $server_package_name = undef
       $client_package_name = undef
       $sshd_dir = '/etc/ssh'
@@ -30,7 +30,7 @@ class ssh::params {
       $service_name = 'sshd'
       $sftp_server_path = '/usr/libexec/sftp-server'
     }
-    openbsd: {
+    /(?i:openbsd)/: {
       $server_package_name = undef
       $client_package_name = undef
       $sshd_dir = '/etc/ssh'
@@ -40,7 +40,7 @@ class ssh::params {
       $service_name = 'sshd'
       $sftp_server_path = '/usr/libexec/sftp-server'
     }
-    archlinux: {
+    /(?i:archlinux)/: {
       $server_package_name = 'openssh'
       $client_package_name = 'openssh'
       $sshd_dir = '/etc/ssh'
@@ -50,7 +50,7 @@ class ssh::params {
       $service_name = 'sshd.service'
       $sftp_server_path = '/usr/lib/ssh/sftp-server'
     }
-    suse: {
+    /(?i:suse)/: {
       $server_package_name = 'openssh'
       $client_package_name = 'openssh'
       $sshd_dir = '/etc/ssh'
@@ -58,11 +58,11 @@ class ssh::params {
       $ssh_config = '/etc/ssh/ssh_config'
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       case $::operatingsystem {
-        sles: {
+        /(?i:sles)/: {
           $service_name = 'sshd'
           $sftp_server_path = '/usr/lib64/ssh/sftp-server'
         }
-        opensuse: {
+        /(?i:opensuse)/: {
           $service_name = 'sshd'
           $sftp_server_path = '/usr/lib/ssh/sftp-server'
         }
@@ -73,7 +73,7 @@ class ssh::params {
     }
     default: {
       case $::operatingsystem {
-        gentoo: {
+        /(?i:gentoo)/: {
           $server_package_name = 'openssh'
           $client_package_name = 'openssh'
           $sshd_dir = '/etc/ssh'
@@ -83,7 +83,7 @@ class ssh::params {
           $service_name = 'sshd'
           $sftp_server_path = '/usr/lib/misc/sftp-server'
         }
-        amazon: {
+        /(?i:amazon)/: {
           $server_package_name = 'openssh-server'
           $client_package_name = 'openssh-clients'
           $sshd_dir = '/etc/ssh'
@@ -103,7 +103,7 @@ class ssh::params {
   # OpenBSDs openssh doesn't link against PAM, therefore
   # it doesn't know about the UsePAM option
   case $::osfamily {
-    openbsd: {
+    /(?i:openbsd)/: {
       $sshd_default_options = {
         'ChallengeResponseAuthentication' => 'no',
         'X11Forwarding'                   => 'yes',


### PR DESCRIPTION
This module fails on Arch Linux with puppet 4.2.1 as the behavior of case statements has changed. Explicitly specifying the branches in params.pp as case-insensitive regexes should fix this on all OSes.