### PR TITLE
Fix future_parser bug with undef options converted to empty string

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -9,6 +9,7 @@ class ssh::client(
 
   $fin_options = $hiera_options ? {
     undef   => $options,
+    ''      => $options,
     default => $hiera_options,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,16 +18,19 @@ class ssh (
 
   $fin_server_options = $hiera_server_options ? {
     undef   => $server_options,
+    ''      => $client_options,
     default => $hiera_server_options,
   }
 
   $fin_client_options = $hiera_client_options ? {
     undef   => $client_options,
+    ''      => $client_options,
     default => $hiera_client_options,
   }
 
   $fin_users_client_options = $hiera_users_client_options ? {
     undef   => $users_client_options,
+    ''      => $users_client_options,
     default => $hiera_users_client_options,
   }
 


### PR DESCRIPTION
See
https://groups.google.com/forum/#!msg/puppet-users/Q0jrR9grbFI/oAc0Y5hTGtsJ
for more information about this bug

This bug is also mention in issue https://github.com/saz/puppet-ssh/issues/124
There is also a pull request open https://github.com/saz/puppet-ssh/pull/130/files but does not cover all affected options.