### PR TITLE
Change facts to only run on Linux systems

### DIFF
--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,4 +1,5 @@
 Facter.add("ssh_client_version_full") do
+  confine :kernel => 'Linux'
   setcode do
     version = Facter::Util::Resolution.exec('sshd -V 2>&1').
       lines.
@@ -12,6 +13,7 @@ Facter.add("ssh_client_version_full") do
 end
 
 Facter.add("ssh_client_version_major") do
+  confine :kernel => 'Linux'
   setcode do
     version = Facter.value('ssh_client_version_full')
 
@@ -20,6 +22,7 @@ Facter.add("ssh_client_version_major") do
 end
 
 Facter.add("ssh_client_version_release") do
+  confine :kernel => 'Linux'
   setcode do
     version = Facter.value('ssh_client_version_full')
 

--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -1,4 +1,5 @@
 Facter.add("ssh_server_version_full") do
+  confine :kernel => 'Linux'
   setcode do
     # sshd doesn't actually have a -V option (hopefully one will be added),
     # by happy coincidence the usage information that is printed includes the
@@ -15,6 +16,7 @@ Facter.add("ssh_server_version_full") do
 end
 
 Facter.add("ssh_server_version_major") do
+  confine :kernel => 'Linux'
   setcode do
     version = Facter.value('ssh_server_version_full')
 
@@ -23,6 +25,7 @@ Facter.add("ssh_server_version_major") do
 end
 
 Facter.add("ssh_server_version_release") do
+  confine :kernel => 'Linux'
   setcode do
     version = Facter.value('ssh_server_version_full')
 


### PR DESCRIPTION
I've added Linux confine statements to all facts. Our production environment serves both Linux and Windows machines. Windows machines were giving errors while collecting facts because this is not meant to be executed on these machines. This fixes it and preserves Linux functionality of course.