### PR TITLE
added defined type ssh::server::config::setting

### DIFF
--- a/manifests/server/config/setting.pp
+++ b/manifests/server/config/setting.pp
@@ -1,0 +1,27 @@
+define ssh::server::config::setting (
+  $key,
+  $value,
+  $order = '10'
+) {
+
+  if is_bool($value) {
+    $real_value = $value ? {
+      true    => 'yes',
+      false   => 'no',
+      default => undef
+    }
+  } elsif is_array($value) {
+    $real_value = join($value, ' ')
+  } elsif is_hash($value) {
+    fail('Hash values are not supported')
+  } else {
+    $real_value = $value
+  }
+
+  concat::fragment { "ssh_setting_${name}_${key}":
+    target  => $ssh::params::sshd_config,
+    content => "\n# added by Ssh::Server::Config::Setting[${name}]\n${key} ${real_value}\n",
+    order   => $order
+  }
+
+}

--- a/spec/defines/server/config/setting_spec.rb
+++ b/spec/defines/server/config/setting_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+describe 'ssh::server::config::setting', :type => :define do
+
+  let :title do
+    'something'
+  end
+
+  let :facts do {
+    :osfamily       => 'RedHat',
+    :concat_basedir => '/tmp'
+  } end
+
+  describe 'with key => "AllowGroups", value => "group1 group2"' do
+    let :params do {
+      :key   => 'AllowGroups',
+      :value => 'group1 group2'
+    } end
+
+    it {
+      should contain_concat__fragment('ssh_setting_something_AllowGroups').with_content(/\nAllowGroups group1 group2\n/)
+    }
+  end
+
+  describe 'with key => "Somesetting", value => true' do
+    let :params do {
+      :key   => 'Somesetting',
+      :value => true
+    } end
+
+    it {
+      should contain_concat__fragment('ssh_setting_something_Somesetting').with_content(/\nSomesetting yes\n/)
+    }
+  end
+
+  describe 'with key => "Foo", value => [1, 2]' do
+    let :params do {
+      :key   => 'Foo',
+      :value => [1, 2]
+    } end
+
+    it {
+      should contain_concat__fragment('ssh_setting_something_Foo').with_content(/\nFoo 1 2\n/)
+    }
+  end
+
+  describe 'with key => "Bar", value => {"a" => "b"}' do
+    let :params do {
+      :key   => 'Bar',
+      :value => {
+        'a' => 'b'
+      }
+    } end
+
+    it 'should fail' do
+      expect {
+        should compile
+      }.to raise_error(/Hash values are not supported/)
+    end
+  end
+end
+
+# vim: tabstop=2 shiftwidth=2 softtabstop=2


### PR DESCRIPTION
Our use case is to allow different profile classes to have the ability to individually manage sshd_config entries without having to centrally manage the entire file from one single location the manifest

It could be done with concat::fragment outside of the module ofc but it is cleaner to have an interface in the module for this in my opinion

For example:

```
class profile::profile1 {
  ssh::server::config::setting { 'profile1':
    key => 'AllowGroups',
    value => 'profile1group'
  }
}

class profile::sshserver {
  class { 'ssh::server':
    options => {
      'AllowGroups' => 'basegroup'
    }
  }
}
```