### PR TITLE
guard inclusion of ssh::knownhosts in client.pp and server.pp.

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -25,15 +25,21 @@ class ssh::client(
   # Provide option to *not* use storeconfigs/puppetdb, which means not managing
   #  hostkeys and knownhosts
   if ($storeconfigs_enabled) {
-    class { 'ssh::knownhosts':
-      collect_enabled => $collect_enabled
+    if !defined('ssh::knownhosts') {
+      class { 'ssh::knownhosts':
+        collect_enabled => $collect_enabled
+      }
+      Anchor['ssh::client::start'] ->
+      Class['ssh::client::install'] ->
+      Class['ssh::client::config'] ->
+      Class['ssh::knownhosts'] ->
+      Anchor['ssh::client::end']
+    } else {
+      Anchor['ssh::client::start'] ->
+      Class['ssh::client::install'] ->
+      Class['ssh::client::config'] ->
+      Anchor['ssh::client::end']
     }
-
-    Anchor['ssh::client::start'] ->
-    Class['ssh::client::install'] ->
-    Class['ssh::client::config'] ->
-    Class['ssh::knownhosts'] ->
-    Anchor['ssh::client::end']
   } else {
     Anchor['ssh::client::start'] ->
     Class['ssh::client::install'] ->

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -27,17 +27,24 @@ class ssh::server(
   #  hostkeys and knownhosts
   if ($storeconfigs_enabled) {
     include ssh::hostkeys
-    class { 'ssh::knownhosts':
-      collect_enabled => $collect_enabled
+    if !defined('ssh::knownhosts') {
+      class { 'ssh::knownhosts':
+        collect_enabled => $collect_enabled
+      }
+      Anchor['ssh::server::start'] ->
+      Class['ssh::server::install'] ->
+      Class['ssh::server::config'] ~>
+      Class['ssh::server::service'] ->
+      Class['ssh::hostkeys'] ->
+      Class['ssh::knownhosts'] ->
+      Anchor['ssh::server::end']
+    } else {
+      Anchor['ssh::server::start'] ->
+      Class['ssh::server::install'] ->
+      Class['ssh::server::config'] ~>
+      Class['ssh::server::service'] ->
+      Anchor['ssh::server::end']
     }
-
-    Anchor['ssh::server::start'] ->
-    Class['ssh::server::install'] ->
-    Class['ssh::server::config'] ~>
-    Class['ssh::server::service'] ->
-    Class['ssh::hostkeys'] ->
-    Class['ssh::knownhosts'] ->
-    Anchor['ssh::server::end']
   } else {
     Anchor['ssh::server::start'] ->
     Class['ssh::server::install'] ->


### PR DESCRIPTION
When both client and server are used on the same hosts, with store_configs enabled,
then it will clash with error:

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Resource Statement, Duplicate declaration: Class[Ssh::Knownhosts] is already declared in file /etc/puppet/environments/production/modules/ssh/manifests/server.pp:30; cannot redeclare at /etc/puppet/environments/production/modules/ssh/manifests/client.pp:28 at /etc/puppet/environments/production/modules/ssh/manifests/client.pp:28:5 on node ...

this prevents that.