### PR TITLE
Restore previous ssh::knownhosts behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ pkg/
 .DS_Store
 Gemfile.lock
 vendor/
+.bundle/

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,7 +1,6 @@
 class ssh::client(
   $ensure               = present,
   $storeconfigs_enabled = true,
-  $collect_enabled      = true,
   $options              = {}
 ) inherits ssh::params {
 
@@ -25,9 +24,7 @@ class ssh::client(
   # Provide option to *not* use storeconfigs/puppetdb, which means not managing
   #  hostkeys and knownhosts
   if ($storeconfigs_enabled) {
-    class { 'ssh::knownhosts':
-      collect_enabled => $collect_enabled
-    }
+    include ssh::knownhosts
 
     Anchor['ssh::client::start'] ->
     Class['ssh::client::install'] ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,6 @@ class ssh (
   $users_client_options = {},
   $version              = 'present',
   $storeconfigs_enabled = true,
-  $collect_enabled      = true
 ) inherits ssh::params {
 
   validate_hash($server_options)
@@ -14,7 +13,6 @@ class ssh (
   validate_hash($client_options)
   validate_hash($users_client_options)
   validate_bool($storeconfigs_enabled)
-  validate_bool($collect_enabled)
 
   # Merge hashes from multiple layer of hierarchy in hiera
   $hiera_server_options = hiera_hash("${module_name}::server_options", undef)
@@ -48,14 +46,12 @@ class ssh (
   class { 'ssh::server':
     ensure               => $version,
     storeconfigs_enabled => $storeconfigs_enabled,
-    collect_enabled      => $collect_enabled,
     options              => $fin_server_options,
   }
 
   class { 'ssh::client':
     ensure               => $version,
     storeconfigs_enabled => $storeconfigs_enabled,
-    collect_enabled      => $collect_enabled,
     options              => $fin_client_options,
   }
 

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -1,6 +1,6 @@
 class ssh::knownhosts(
-  $collect_enabled = true
-) {
+  $collect_enabled = $ssh::params::collect_enabled,
+) inherits ssh::params {
   if ($collect_enabled) {
     Sshkey <<| |>>
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -176,4 +176,5 @@ class ssh::params {
 
   $user_ssh_directory_default_mode = '0700'
   $user_ssh_config_default_mode    = '0600'
+  $collect_enabled                 = true   # Collect sshkey resources
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,7 +1,6 @@
 class ssh::server(
   $ensure               = present,
   $storeconfigs_enabled = true,
-  $collect_enabled      = true,
   $options              = {}
 ) inherits ssh::params {
 
@@ -27,9 +26,7 @@ class ssh::server(
   #  hostkeys and knownhosts
   if ($storeconfigs_enabled) {
     include ssh::hostkeys
-    class { 'ssh::knownhosts':
-      collect_enabled => $collect_enabled
-    }
+    include ssh::knownhosts
 
     Anchor['ssh::server::start'] ->
     Class['ssh::server::install'] ->

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe 'ssh', :type => 'class' do
+    context "On Debian with no other parameters" do
+        let :facts do
+        {
+            :osfamily => 'Debian',
+            :interfaces => 'eth0',
+            :ipaddress_eth0 => '192.168.1.1',
+            :concat_basedir => '/tmp'
+        }
+        end
+        it {
+            should contain_class('ssh::client')
+        }
+        it {
+            should contain_class('ssh::server')
+        }
+    end
+end


### PR DESCRIPTION
Create spec test for include ::ssh (which includes both ssh:server ssh:client).
Include classes instead of instantiate them.

This issue was introduced in #145 