### PR TITLE
Check for sshd is installed

### DIFF
--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,19 +1,23 @@
 Facter.add("ssh_client_version_full") do
   confine :kernel => [ 'Linux' , 'SunOS' , 'FreeBSD' , 'Darwin' ]
-  setcode do
-    version = Facter::Util::Resolution.exec('sshd -V 2>&1').
-      lines.
-      to_a.
-      select { |line| line.match(/^OpenSSH_/) }.
-      first.
-      rstrip
 
-    version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+  version = Facter::Util::Resolution.exec('sshd -V 2>&1').
+    lines.
+    to_a.
+    select { |line| line.match(/^OpenSSH_/) }.
+    first.
+    rstrip
+
+  setcode do
+    if not version.nil?
+      version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+    end
   end
 end
 
 Facter.add("ssh_client_version_major") do
   confine :kernel => [ 'Linux' , 'SunOS' , 'FreeBSD' , 'Darwin' ]
+  confine :ssh_client_version_full => true
   setcode do
     version = Facter.value('ssh_client_version_full')
 
@@ -23,6 +27,7 @@ end
 
 Facter.add("ssh_client_version_release") do
   confine :kernel => [ 'Linux' , 'SunOS' , 'FreeBSD' , 'Darwin' ]
+  confine :ssh_client_version_full => true
   setcode do
     version = Facter.value('ssh_client_version_full')
 

--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,7 +1,7 @@
 Facter.add("ssh_client_version_full") do
   confine :kernel => [ 'Linux' , 'SunOS' , 'FreeBSD' , 'Darwin' ]
 
-  version = Facter::Util::Resolution.exec('sshd -V 2>&1').
+  version = Facter::Util::Resolution.exec('ssh -V 2>&1').
     lines.
     to_a.
     select { |line| line.match(/^OpenSSH_/) }.

--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -1,22 +1,26 @@
 Facter.add("ssh_server_version_full") do
   confine :kernel => [ 'Linux' , 'SunOS' , 'FreeBSD' , 'Darwin' ]
-  setcode do
-    # sshd doesn't actually have a -V option (hopefully one will be added),
-    # by happy coincidence the usage information that is printed includes the
-    # version number.
-    version = Facter::Util::Resolution.exec('sshd -V 2>&1').
-      lines.
-      to_a.
-      select { |line| line.match(/^OpenSSH_/) }.
-      first.
-      rstrip
 
-    version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+  # sshd doesn't actually have a -V option (hopefully one will be added),
+  # by happy coincidence the usage information that is printed includes the
+  # version number.
+  version = Facter::Util::Resolution.exec('sshd -V 2>&1').
+    lines.
+    to_a.
+    select { |line| line.match(/^OpenSSH_/) }.
+    first.
+    rstrip
+
+  setcode do
+    if not version.nil?
+      version.gsub(/^OpenSSH_([^ ]+).*$/, '\1')
+    end
   end
 end
 
 Facter.add("ssh_server_version_major") do
   confine :kernel => [ 'Linux' , 'SunOS' , 'FreeBSD' , 'Darwin' ]
+  confine :ssh_server_version_full => true
   setcode do
     version = Facter.value('ssh_server_version_full')
 
@@ -26,6 +30,7 @@ end
 
 Facter.add("ssh_server_version_release") do
   confine :kernel => [ 'Linux' , 'SunOS' , 'FreeBSD' , 'Darwin' ]
+  confine :ssh_server_version_full => true
   setcode do
     version = Facter.value('ssh_server_version_full')
 


### PR DESCRIPTION
We can use this module in some env (for example, docker) which
doesn't have openssh-server package installed. As the result the following error occurred:

```
   Could not retrieve ssh_client_version_full: undefined method `lines' for nil:NilClass
   Could not retrieve ssh_client_version_full: undefined method `lines' for nil:NilClass
   Could not retrieve ssh_client_version_full: undefined method `lines' for nil:NilClass
   Could not retrieve ssh_client_version_full: undefined method `lines' for nil:NilClass
   Could not retrieve ssh_client_version_major: undefined method `gsub' for nil:NilClass
   ...

```
So we need to have some basic check for nil

PS. Related to https://github.com/saz/puppet-ssh/pull/148 