### PR TITLE
server_options should default to server_options, not client_options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class ssh (
 
   $fin_server_options = $hiera_server_options ? {
     undef   => $server_options,
-    ''      => $client_options,
+    ''      => $server_options,
     default => $hiera_server_options,
   }
 


### PR DESCRIPTION
in init.pp.

I think that went in with 404525671d3db9aeeccd8b339f70d4dcd66e58ed