### PR TITLE
fix create_resources of server_match_block in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class ssh (
 
   $fin_server_match_block = $hiera_server_match_block ? {
     undef   => $server_match_block,
+    ''      => $server_match_block,
     default => $hiera_server_match_block,
   }
 


### PR DESCRIPTION
When there is no server_match_block defined in hiera, then the module might bail out with:

==> default: Error: Evaluation Error: Error while evaluating a Function Call, create_resources(): second argument must be a hash at /tmp/vagrant-puppet/modules-829fea09e19ea460b947efb414d877cb/ssh/manifests/init.pp:60:3 on node testvm.vagrant.intern

Do the same pattern as for the other hiera lookups

tested with puppet 3.7.3 on SLES 11 SP3, as well as puppet 3.8.2 on SLES 12, both with hiera 1.3.4 