### PR TITLE
Allow disabling knownhosts bug workaround

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,7 +1,8 @@
 class ssh::client(
   $ensure               = present,
   $storeconfigs_enabled = true,
-  $options              = {}
+  $options              = {},
+  $workaround_PUP1177   = true,
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -11,9 +11,12 @@ class ssh::client::config
     require => Class['ssh::client::install'],
   }
 
-  # Workaround for http://projects.reductivelabs.com/issues/2014
-  file { $ssh::params::ssh_known_hosts:
-    ensure => present,
-    mode   => '0644',
+  # Workaround for https://tickets.puppetlabs.com/browse/PUP-1177.
+  # Fixed in Puppet 3.7.0
+  if $::ssh::client::workaround_PUP1177 {
+    ensure_resource('file', '/etc/ssh/ssh_known_hosts', {
+      'ensure'  => 'file',
+      'mode'    => '0644',
+    })
   }
 }


### PR DESCRIPTION
PUP-1177 was fixed in Puppet 3.7.0, so it's no longer required to manage
this this resource.  This currently conflicts with the puppet-ansible
module which also manages a known_hosts entry.  This allows turning off
management of the resource and also changes it to be an ensure_resource
declaration that is compatible with the one in puppet-ansible.