### PR TITLE
Make ipaddresses optional

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -1,8 +1,14 @@
 # Class ssh::hostkeys
-class ssh::hostkeys {
-  $ipaddresses  = ipaddresses()
-  $host_aliases = flatten([ $::fqdn, $::hostname, $ipaddresses ])
-
+class ssh::hostkeys(
+  $export_ipaddresses = true
+) {
+  if $export_ipaddresses == true {
+    $ipaddresses  = ipaddresses()
+    $host_aliases = flatten([ $::fqdn, $::hostname, $ipaddresses ])
+  } else {
+    $host_aliases = flatten([ $::fqdn, $::hostname ])
+  }
+  
   if $::sshdsakey {
     @@sshkey { "${::fqdn}_dsa":
       ensure       => present,


### PR DESCRIPTION
Hi,

i dont to export all ipaddresses  from a host, since it be can a lot for hypervisor oder docker hosts.

With this option, I can set ssh::hostkeys::export_ipaddresses to false in hiera for every host i want.