### PR TITLE
Adds validate_cmd parameter for sshd config file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -145,7 +145,7 @@ SSH configuration file will be `/home/bob/.ssh/config`.
 
 **User's home is passed to define type**
 
-SSH configuration file will be `/var/lib/bob/.ssh/config` and puppet will 
+SSH configuration file will be `/var/lib/bob/.ssh/config` and puppet will
 manage directory `/var/lib/bob/.ssh`.
 
 ```puppet
@@ -212,7 +212,18 @@ or
       },
     }
 ```
- 
+
+### Validate config before replacing it
+
+`validate_sshd_file` allows you to run `/usr/sbin/sshd -tf` against the sshd config file before it gets replaced, and will raise an error if the config is incorrect.
+
+```
+class { 'ssh::server':
+  validate_sshd_file => true,
+}
+```
+
+
 ## Default options
 
 ### Client
@@ -224,7 +235,7 @@ or
       'GSSAPIAuthentication' => 'yes',
     }
 ```
- 
+
 ### Server
 
 ```
@@ -235,7 +246,7 @@ or
     'Subsystem'                       => 'sftp /usr/lib/openssh/sftp-server',
     'UsePAM'                          => 'yes',
 ```
- 
+
 ## Overwriting default options
 Default options will be merged with options passed in.
 If an option is set both as default and via options parameter, the latter will
@@ -317,7 +328,7 @@ Both of these definitions will create ```/etc/ssh/ssh_host_rsa_key``` and
 ## Adding custom match blocks
 
 ```
-class YOURCUSTOMCLASS { 
+class YOURCUSTOMCLASS {
 
   include ssh
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,7 @@ class ssh (
   $users_client_options = {},
   $version              = 'present',
   $storeconfigs_enabled = true,
+  $validate_sshd_file   = $::ssh::validate_sshd_file,
 ) inherits ssh::params {
 
   validate_hash($server_options)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -177,4 +177,6 @@ class ssh::params {
   $user_ssh_directory_default_mode = '0700'
   $user_ssh_config_default_mode    = '0600'
   $collect_enabled                 = true   # Collect sshkey resources
+
+  $validate_sshd_file              = false
 }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,11 +1,21 @@
 class ssh::server::config {
 
+  case $ssh::validate_sshd_file {
+    false: {
+      $sshd_validate_cmd = '/usr/sbin/sshd -tf %'
+    }
+    default: {
+      $sshd_validate_cmd = undef
+    }
+  }
+
   concat { $ssh::params::sshd_config:
-    ensure => present,
-    owner  => '0',
-    group  => '0',
-    mode   => '0600',
-    notify => Service[$ssh::params::service_name]
+    ensure       => present,
+    owner        => '0',
+    group        => '0',
+    mode         => '0600',
+    validate_cmd => $sshd_validate_cmd,
+    notify       => Service[$ssh::params::service_name]
   }
 
   concat::fragment { 'global config':


### PR DESCRIPTION
Got bit by this today, managed to give a bad config that killed sshd. Which then stopped the service from running, so I was locked out the box! :cry:

`validate_cmd` allows us to check a file with a given test command before it's replaced. So we can check it works before we replace it.

This is false by default, as it requires Puppet 3.6+, plus it could be unexpected behavior.