### PR TITLE
Make the module work on SLES 12 as well as on Ubuntu 15.10

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,14 @@ class ssh::params {
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       $service_name = 'ssh'
       $sftp_server_path = '/usr/lib/openssh/sftp-server'
+      case $::operatingsystemmajrelease {
+        '15.10': {
+          $service_provider = 'systemd'
+        }
+        default: {
+          $service_provider = undef
+        }
+      }
     }
     redhat: {
       $server_package_name = 'openssh-server'
@@ -61,6 +69,14 @@ class ssh::params {
         sles: {
           $service_name = 'sshd'
           $sftp_server_path = '/usr/lib64/ssh/sftp-server'
+          case $::operatingsystemmajrelease {
+            '11': {
+              $service_provider = undef
+            }
+            default: {
+              $service_provider = 'systemd'
+            }
+          }
         }
         opensuse: {
           $service_name = 'sshd'

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -9,6 +9,7 @@ class ssh::server::service (
     ensure     => $ssh::server::service::ensure,
     hasstatus  => true,
     hasrestart => true,
+    provider   => $::ssh::params::service_provider,
     enable     => $ssh::server::service::enable,
     require    => Class['ssh::server::config'],
   }


### PR DESCRIPTION
For both OS versions, the default service provider chose by puppet is not correct. for SLES 12 as well as for Ubuntu 15.10 the service provider to use is systemd.

For Ubuntu, I made it the default to undef, and only set it for the 15.10 release to systemd.
For SLES, it defaults to 'systemd', and only for SLES 11 kept it on undef, since there I know it's picking the right one (init).

please let me know if there is something to change/enhance/...