### PR TITLE
Allow segregation of groups for hostkeys

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -1,6 +1,7 @@
 # Class ssh::hostkeys
 class ssh::hostkeys(
-  $export_ipaddresses = true
+  $export_ipaddresses = true,
+  $storeconfigs_group = undef,
 ) {
   if $export_ipaddresses == true {
     $ipaddresses  = ipaddresses()
@@ -8,6 +9,8 @@ class ssh::hostkeys(
   } else {
     $host_aliases = flatten([ $::fqdn, $::hostname ])
   }
+
+  tag 'hostkey_all', "hostkey_${storeconfigs_group}"
 
   if $::sshdsakey {
     @@sshkey { "${::fqdn}_dsa":

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -1,11 +1,12 @@
 class ssh::knownhosts(
   $collect_enabled = $ssh::params::collect_enabled,
+  $storeconfigs_group = undef,
 ) inherits ssh::params {
   if ($collect_enabled) {
     resources { 'sshkey':
       purge => true,
     }
 
-    Sshkey <<| |>>
+    Sshkey <<| tag == "hostkey_${storeconfigs_group}" |>>
   }
 }


### PR DESCRIPTION
We do not want to deploy all host keys to all servers, therefore we use tagging. Would be great to have this feature upstream available.
