### PR TITLE
Fix hiera usage to work with future parser

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -5,12 +5,12 @@ class ssh::client(
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera
-  $hiera_options = hiera_hash("${module_name}::client::options", undef)
+  $hiera_options = hiera_hash("${module_name}::client::options", {})
 
-  $fin_options = $hiera_options ? {
-    undef   => $options,
-    ''      => $options,
-    default => $hiera_options,
+  if empty($hiera_options) {
+    $fin_options = $options
+  } else {
+    $fin_options = $hiera_options
   }
 
   $merged_options = merge($ssh::params::ssh_default_options, $fin_options)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,32 +15,33 @@ class ssh (
   validate_bool($storeconfigs_enabled)
 
   # Merge hashes from multiple layer of hierarchy in hiera
-  $hiera_server_options = hiera_hash("${module_name}::server_options", undef)
-  $hiera_server_match_block = hiera_hash("${module_name}::server_match_block", undef)
-  $hiera_client_options = hiera_hash("${module_name}::client_options", undef)
-  $hiera_users_client_options = hiera_hash("${module_name}::users_client_options", undef)
+  $hiera_server_options = hiera_hash("${module_name}::server_options", {})
+  $hiera_server_match_block = hiera_hash("${module_name}::server_match_block", {})
+  $hiera_client_options = hiera_hash("${module_name}::client_options", {})
+  $hiera_users_client_options = hiera_hash("${module_name}::users_client_options", {})
 
-  $fin_server_options = $hiera_server_options ? {
-    undef   => $server_options,
-    ''      => $client_options,
-    default => $hiera_server_options,
+  if empty($hiera_server_options) {
+    $fin_server_options = $server_options
+  } else {
+    $fin_server_options = $hiera_server_options
   }
 
-  $fin_server_match_block = $hiera_server_match_block ? {
-    undef   => $server_match_block,
-    default => $hiera_server_match_block,
+  if empty($hiera_server_match_block) {
+    $fin_server_match_block = $server_match_block
+  } else {
+    $fin_server_match_block = $hiera_server_match_block
   }
 
-  $fin_client_options = $hiera_client_options ? {
-    undef   => $client_options,
-    ''      => $client_options,
-    default => $hiera_client_options,
+  if empty($hiera_client_options) {
+    $fin_client_options = $client_options
+  } else {
+    $fin_client_options = $hiera_client_options
   }
 
-  $fin_users_client_options = $hiera_users_client_options ? {
-    undef   => $users_client_options,
-    ''      => $users_client_options,
-    default => $hiera_users_client_options,
+  if empty($hiera_users_client_options) {
+    $fin_users_client_options = $users_client_options
+  } else {
+    $fin_users_client_options = $hiera_users_client_options
   }
 
   class { 'ssh::server':

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -5,12 +5,12 @@ class ssh::server(
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera
-  $hiera_options = hiera_hash("${module_name}::server::options", undef)
+  $hiera_options = hiera_hash("${module_name}::server::options", {})
 
-  $fin_options = $hiera_options ? {
-    undef   => $options,
-    ''      => $options,
-    default => $hiera_options,
+  if empty($hiera_options) {
+    $fin_options = $options
+  } else {
+    $fin_options = $hiera_options
   }
 
   $merged_options = merge($ssh::params::sshd_default_options, $fin_options)


### PR DESCRIPTION
Using this module in a profile with FUTURE_PARSER=yes results in messages like this:
```
Puppet::Error:
       Evaluation Error: Error while evaluating a Function Call, Could not find data item ssh::server_options in any Hiera data file and no default supplied at spec/fixtures/modules/ssh/manifests/init.pp:18:27
```
The changes resolve the error and should not change behavior of module.

