### PR TITLE
Add concat dependency to Requirements.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -10,6 +10,7 @@ Source: https://github.com/saz/puppet-ssh
 ## Requirements
 * Exported resources for host keys management
 * puppetlabs/stdlib
+* puppetlabs/concat
 
 ## Usage
 


### PR DESCRIPTION
I just stumbled upon this. The requirements are not fully reflected in the Readme.md. This fixes it.