### PR TITLE
Respect order of ssh_config options specified by the user

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -18,7 +18,7 @@ class ssh::client(
   if $use_augeas {
     $merged_options = sshclient_options_to_augeas_ssh_config($fin_options, $options_absent, { 'target' => $::ssh::params::ssh_config })
   } else {
-    $merged_options = merge($ssh::params::ssh_default_options, $fin_options)
+    $merged_options = merge($fin_options, delete($ssh::params::ssh_default_options, keys($fin_options)))
   }
 
   include ::ssh::client::install

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -12,7 +12,7 @@
   end
 -%>
 
-<%- @options.sort.each do |k, v| -%>
+<%- @options.each do |k, v| -%>
 <%- if v.is_a?(Hash) -%>
 <%- if k.length > 1024 -%>
 <%- fail("Line exceeds 1024 characters: #{k}") -%>


### PR DESCRIPTION
According to the ssh_config man page "more host-specific declarations
should be given near the beginning of the file, and general defaults at
the end." Since the order of the options matters, alphabetic sorting of
ssh_config options is switched off and it is made sure that default
options are added at the end of the file.
