### PR TITLE
Fix additional server options in template for newer Puppet

### DIFF
--- a/manifests/server/match_block.pp
+++ b/manifests/server/match_block.pp
@@ -2,6 +2,6 @@ define ssh::server::match_block ($options, $type = 'user', $order = 50,) {
   concat::fragment { "match_block ${name}":
     target  => $ssh::params::sshd_config,
     content => template("${module_name}/sshd_match_block.erb"),
-    order   => $order,
+    order   => 200+$order,
   }
 }

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -2,6 +2,6 @@ define ssh::server::options ($options, $order = 50) {
   concat::fragment { "options ${name}":
     target  => $ssh::params::sshd_config,
     content => template("${module_name}/options.erb"),
-    order   => $order,
+    order   => 100+$order,
   }
 }

--- a/templates/options.erb
+++ b/templates/options.erb
@@ -10,8 +10,8 @@
     end
   end
 -%>
-<%- options.keys.sort_by{ |sk| (sk.to_s.downcase.include? "match") ? 'zzz' + sk.to_s : sk.to_s }.each do |k| -%>
-<%- v = options[k] -%>
+<%- @options.keys.sort_by{ |sk| (sk.to_s.downcase.include? "match") ? 'zzz' + sk.to_s : sk.to_s }.each do |k| -%>
+<%- v = @options[k] -%>
 <%- if v.is_a?(Hash) -%>
 <%= k %>
 <%- v.keys.sort.each do |key| -%>


### PR DESCRIPTION
This PR fixes following problem with additional server options in template:
```
  Detail: undefined local variable or method `options' for #<Puppet::Parser::TemplateWrapper:0x264659dc>
```
and adds proper options and match block ordering.