### PR TITLE
Use the 'defined' function to check if a variable is set

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -9,7 +9,7 @@ class ssh::hostkeys(
     $host_aliases = flatten([ $::fqdn, $::hostname ])
   }
 
-  if $::sshdsakey {
+  if defined('$::sshdsakey') {
     @@sshkey { "${::fqdn}_dsa":
       ensure       => present,
       host_aliases => $host_aliases,
@@ -21,7 +21,7 @@ class ssh::hostkeys(
       ensure => absent,
     }
   }
-  if $::sshrsakey {
+  if defined('$::sshrsakey') {
     @@sshkey { "${::fqdn}_rsa":
       ensure       => present,
       host_aliases => $host_aliases,
@@ -33,7 +33,7 @@ class ssh::hostkeys(
       ensure => absent,
     }
   }
-  if $::sshecdsakey {
+  if defined('$::sshecdsakey') {
     @@sshkey { "${::fqdn}_ecdsa":
       ensure       => present,
       host_aliases => $host_aliases,
@@ -46,7 +46,7 @@ class ssh::hostkeys(
       type   => 'ecdsa-sha2-nistp256',
     }
   }
-  if $::sshed25519key {
+  if defined('$::sshed25519key') {
     @@sshkey { "${::fqdn}_ed25519":
       ensure       => present,
       host_aliases => $host_aliases,


### PR DESCRIPTION
Referencing variables that are not declared will fail when the 'strict_variables' setting is set to 'true'.
