### PR TITLE
remove sort from options

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet_blacksmith/rake_tasks'
 require 'voxpupuli/release/rake_tasks'
-require 'puppet-strings/rake_tasks'
+require 'puppet-strings/tasks'
 
 if RUBY_VERSION >= '2.2.0'
   require 'rubocop/rake_task'

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -12,7 +12,7 @@
   end
 -%>
 
-<%- @options.sort.each do |k, v| -%>
+<%- @options.each do |k, v| -%>
 <%- if v.is_a?(Hash) -%>
 <%- if k.length > 1024 -%>
 <%- fail("Line exceeds 1024 characters: #{k}") -%>


### PR DESCRIPTION
sorting config options can place 'Host' entries before boolean values (i.e. StrictHostKeyChecking) which causes ssh to ignore those boolean options.