### PR TITLE
Support Puppet 4 in metadata.json, bump dependency versions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,6 @@
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
-    concat:
-      repo: "https://github.com/puppetlabs/puppetlabs-concat"
-      ref: "1.2.0"
+    concat: "https://github.com/puppetlabs/puppetlabs-concat"
   symlinks:
     ssh: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -33,12 +33,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": "3.2.x"
-    },
-    {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "name": "saz-ssh",
@@ -52,11 +48,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.2.1"
+      "version_requirement": ">= 4.6.0 < 5.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.0"
+      "version_requirement": ">= 1.2.5 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
Bump dependencies to the minimum version that should work under Puppet 4, based on the metadata

Remove deprecated pe field in metadata.json