### PR TITLE
Fixes issue with fact on different version strings

### DIFF
--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -17,7 +17,6 @@ end
 
 Facter.add('ssh_client_version_major') do
   confine :kernel => %w(Linux SunOS FreeBSD Darwin)
-  confine :ssh_client_version_full => true
   setcode do
     version = Facter.value('ssh_client_version_full')
 
@@ -27,7 +26,6 @@ end
 
 Facter.add('ssh_client_version_release') do
   confine :kernel => %w(Linux SunOS FreeBSD Darwin)
-  confine :ssh_client_version_full => true
   setcode do
     version = Facter.value('ssh_client_version_full')
 

--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -20,17 +20,25 @@ end
 
 Facter.add('ssh_server_version_major') do
   confine :kernel => %w(Linux SunOS FreeBSD Darwin)
-  confine :ssh_server_version_full => true
+  confine :ssh_server_version_full => /\d+/
   setcode do
     version = Facter.value('ssh_server_version_full')
 
-    version.gsub(%r{^([0-9]+\.[0-9]+).*$}, '\1') unless version.nil?
+    case version
+    when /([0-9]+)\.([0-9]+)\.([0-9]+p[0-9]+)/
+      # 6.6.1p1 style formatting
+      version.gsub(%r{([0-9]+)\.([0-9]+)\.([0-9]+p[0-9]+)}, '\1')
+    when /^([0-9]+)\.([0-9]+p[0-9]+)/
+      # 7.2p2 style formatting
+      version.gsub(%r{^([0-9]+)\.([0-9]+p[0-9]+)}, '\1')
+    end
+
   end
 end
 
 Facter.add('ssh_server_version_release') do
   confine :kernel => %w(Linux SunOS FreeBSD Darwin)
-  confine :ssh_server_version_full => true
+  confine :ssh_server_version_full => /\d+/
   setcode do
     version = Facter.value('ssh_server_version_full')
 

--- a/spec/unit/facter/ssh_client_version_spec.rb
+++ b/spec/unit/facter/ssh_client_version_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'ssh_client_version_full' do
   before do
+    Facter.clear
     Facter.fact(:kernel).stubs(:value).returns('linux')
   end
   context 'on a Linux host' do

--- a/spec/unit/facter/ssh_server_version_major_spec.rb
+++ b/spec/unit/facter/ssh_server_version_major_spec.rb
@@ -1,0 +1,41 @@
+require "spec_helper"
+
+describe Facter::Util::Fact do
+  before do
+    Facter.clear
+    Facter.fact(:kernel).stubs(:value).returns('linux')
+  end
+
+  describe "ssh_server_version_major" do
+    context '3 point semver syntax (6.6.1p1)' do
+      context 'returns major version when ssh_server_version_full fact present' do
+        before :each do
+          Facter.fact(:ssh_server_version_full).stubs(:value).returns('6.6.1p1')
+        end
+        it do
+          expect(Facter.fact(:ssh_server_version_major).value).to eq("6")
+        end
+      end
+    end
+
+    context '2 point semver syntax (7.2p2)' do
+      context 'returns major version when ssh_server_version_full fact present' do
+        before :each do
+          Facter.fact(:ssh_server_version_full).stubs(:value).returns('7.2p2')
+        end
+        it do
+          expect(Facter.fact(:ssh_server_version_major).value).to eq("7")
+        end
+      end
+    end
+
+    context 'returns nil when ssh_server_version_full fact not present' do
+      before :each do
+        Facter.fact(:ssh_server_version_full).stubs(:value).returns(nil)
+      end
+      it do
+        expect(Facter.fact(:ssh_server_version_major).value).to be_nil
+      end
+    end
+  end
+end

--- a/spec/unit/facter/ssh_server_version_spec.rb
+++ b/spec/unit/facter/ssh_server_version_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'ssh_server_version_full' do
   before do
+    Facter.clear
     Facter.fact(:kernel).stubs(:value).returns('linux')
   end
   context 'on a Linux host' do


### PR DESCRIPTION
* ssh versions can in the format `7.2p2`
* Update the fact regex and add unit test for this
* Clears facter runs to fix tests
* Changes confines to check for a regex of a digit
* The confine before was for truth: this would not work as the values are strings, not booleans