### PR TITLE
add way to add host aliases to the exported sshkeys

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,8 @@
 fixtures:
   repositories:
     stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib"
-    concat: "https://github.com/puppetlabs/puppetlabs-concat"
+    concat:
+      repo: "https://github.com/puppetlabs/puppetlabs-concat"
+      ref: "2.1.x"
   symlinks:
     ssh: "#{source_dir}"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -298,7 +298,7 @@ Style/EmptyLiteral:
 Metrics/LineLength:
   Enabled: false
 
-Style/MethodCallParentheses:
+Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
 Style/MethodDefParentheses:
@@ -495,7 +495,7 @@ Style/ClosingParenthesisIndentation:
   Enabled: false
 
 BlockLength:
-      Max: 70
+  Max: 70
 
 # RSpec
 
@@ -508,4 +508,4 @@ RSpec/ExampleLength:
   Enabled: False
 
 RSpec/NestedGroups:
-    MaxNesting: 5
+  Max: 5

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -32,15 +32,15 @@ class ssh::client(
   if ($storeconfigs_enabled) {
     include ::ssh::knownhosts
 
-    Anchor['ssh::client::start'] ->
-    Class['ssh::client::install'] ->
-    Class['ssh::client::config'] ->
-    Class['ssh::knownhosts'] ->
-    Anchor['ssh::client::end']
+    Anchor['ssh::client::start']
+    -> Class['ssh::client::install']
+    -> Class['ssh::client::config']
+    -> Class['ssh::knownhosts']
+    -> Anchor['ssh::client::end']
   } else {
-    Anchor['ssh::client::start'] ->
-    Class['ssh::client::install'] ->
-    Class['ssh::client::config'] ->
-    Anchor['ssh::client::end']
+    Anchor['ssh::client::start']
+    -> Class['ssh::client::install']
+    -> Class['ssh::client::config']
+    -> Anchor['ssh::client::end']
   }
 }

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -2,12 +2,15 @@
 class ssh::hostkeys(
   $export_ipaddresses = true,
   $storeconfigs_group = undef,
+  $extra_aliases = [],
 ) {
+  validate_array($extra_aliases)
+
   if $export_ipaddresses == true {
     $ipaddresses  = ipaddresses()
-    $host_aliases = flatten([ $::fqdn, $::hostname, $ipaddresses ])
+    $host_aliases = flatten([ $::fqdn, $::hostname, $extra_aliases, $ipaddresses ])
   } else {
-    $host_aliases = flatten([ $::fqdn, $::hostname ])
+    $host_aliases = flatten([ $::fqdn, $::hostname, $extra_aliases])
   }
 
   if $storeconfigs_group {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -35,18 +35,18 @@ class ssh::server(
     include ::ssh::hostkeys
     include ::ssh::knownhosts
 
-    Anchor['ssh::server::start'] ->
-    Class['ssh::server::install'] ->
-    Class['ssh::server::config'] ~>
-    Class['ssh::server::service'] ->
-    Class['ssh::hostkeys'] ->
-    Class['ssh::knownhosts'] ->
-    Anchor['ssh::server::end']
+    Anchor['ssh::server::start']
+    -> Class['ssh::server::install']
+    -> Class['ssh::server::config']
+    ~> Class['ssh::server::service']
+    -> Class['ssh::hostkeys']
+    -> Class['ssh::knownhosts']
+    -> Anchor['ssh::server::end']
   } else {
-    Anchor['ssh::server::start'] ->
-    Class['ssh::server::install'] ->
-    Class['ssh::server::config'] ~>
-    Class['ssh::server::service'] ->
-    Anchor['ssh::server::end']
+    Anchor['ssh::server::start']
+    -> Class['ssh::server::install']
+    -> Class['ssh::server::config']
+    ~> Class['ssh::server::service']
+    -> Anchor['ssh::server::end']
   }
 }


### PR DESCRIPTION
This makes working with roles and/or hiera more comfortable, since this becomes possible:
```yaml
# some_role.yaml
ssh::hostkeys::extra_aliases:
  - some.domain.behind.load-balancer
```