### PR TITLE
removed solaris from facter

### DIFF
--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,5 +1,5 @@
 Facter.add('ssh_client_version_full') do
-  confine :kernel => %w(Linux SunOS FreeBSD Darwin)
+  confine :kernel => %w(Linux FreeBSD Darwin)
 
   setcode do
     if Facter::Util::Resolution.which('ssh')
@@ -16,7 +16,7 @@ Facter.add('ssh_client_version_full') do
 end
 
 Facter.add('ssh_client_version_major') do
-  confine :kernel => %w(Linux SunOS FreeBSD Darwin)
+  confine :kernel => %w(Linux FreeBSD Darwin)
   confine :ssh_client_version_full => true
   setcode do
     version = Facter.value('ssh_client_version_full')
@@ -26,7 +26,7 @@ Facter.add('ssh_client_version_major') do
 end
 
 Facter.add('ssh_client_version_release') do
-  confine :kernel => %w(Linux SunOS FreeBSD Darwin)
+  confine :kernel => %w(Linux FreeBSD Darwin)
   confine :ssh_client_version_full => true
   setcode do
     version = Facter.value('ssh_client_version_full')

--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -1,5 +1,5 @@
 Facter.add('ssh_server_version_full') do
-  confine :kernel => %w(Linux SunOS FreeBSD Darwin)
+  confine :kernel => %w(Linux FreeBSD Darwin)
 
   setcode do
     if Facter::Util::Resolution.which('sshd')
@@ -19,7 +19,7 @@ Facter.add('ssh_server_version_full') do
 end
 
 Facter.add('ssh_server_version_major') do
-  confine :kernel => %w(Linux SunOS FreeBSD Darwin)
+  confine :kernel => %w(Linux FreeBSD Darwin)
   confine :ssh_server_version_full => true
   setcode do
     version = Facter.value('ssh_server_version_full')
@@ -29,7 +29,7 @@ Facter.add('ssh_server_version_major') do
 end
 
 Facter.add('ssh_server_version_release') do
-  confine :kernel => %w(Linux SunOS FreeBSD Darwin)
+  confine :kernel => %w(Linux FreeBSD Darwin)
   confine :ssh_server_version_full => true
   setcode do
     version = Facter.value('ssh_server_version_full')


### PR DESCRIPTION
Solaris is not supported, and this is shown in: https://github.com/saz/puppet-ssh/blob/master/metadata.json

When run on a Solaris machine, facter spits out the following errors: https://ask.puppet.com/question/26546/ssh-module-facter-errors/

Removing SunOS from the facter files fixes this, because again it is not supported.