### PR TITLE
Eject docker based ip addresses from consideration.

### DIFF
--- a/lib/puppet/parser/functions/ipaddresses.rb
+++ b/lib/puppet/parser/functions/ipaddresses.rb
@@ -22,7 +22,7 @@ EOS
         result << ipaddr6 if ipaddr6 && (ipaddr6 != :undefined)
       end
     else
-      unless interfaces.include?('lo') or interfaces.include?('docker')
+      unless interfaces.include?('lo') || interfaces.include?('docker')
         ipaddr = lookupvar("ipaddress_#{interfaces}")
         ipaddr6 = lookupvar("ipaddress6_#{interfaces}")
         result << ipaddr if ipaddr && (ipaddr != :undefined)

--- a/lib/puppet/parser/functions/ipaddresses.rb
+++ b/lib/puppet/parser/functions/ipaddresses.rb
@@ -16,13 +16,14 @@ EOS
       interfaces.each do |iface|
         next if iface.include?('lo')
         next if iface.include?('docker')
+        next if iface.include?('veth')
         ipaddr = lookupvar("ipaddress_#{iface}")
         ipaddr6 = lookupvar("ipaddress6_#{iface}")
         result << ipaddr if ipaddr && (ipaddr != :undefined)
         result << ipaddr6 if ipaddr6 && (ipaddr6 != :undefined)
       end
     else
-      unless interfaces.include?('lo') || interfaces.include?('docker')
+      unless interfaces.include?('lo') || interfaces.include?('docker') || interfaces.include?('veth')
         ipaddr = lookupvar("ipaddress_#{interfaces}")
         ipaddr6 = lookupvar("ipaddress6_#{interfaces}")
         result << ipaddr if ipaddr && (ipaddr != :undefined)

--- a/lib/puppet/parser/functions/ipaddresses.rb
+++ b/lib/puppet/parser/functions/ipaddresses.rb
@@ -15,13 +15,14 @@ EOS
       interfaces = interfaces.split(',')
       interfaces.each do |iface|
         next if iface.include?('lo')
+        next if iface.include?('docker')
         ipaddr = lookupvar("ipaddress_#{iface}")
         ipaddr6 = lookupvar("ipaddress6_#{iface}")
         result << ipaddr if ipaddr && (ipaddr != :undefined)
         result << ipaddr6 if ipaddr6 && (ipaddr6 != :undefined)
       end
     else
-      unless interfaces.include?('lo')
+      unless interfaces.include?('lo') or interfaces.include?('docker')
         ipaddr = lookupvar("ipaddress_#{interfaces}")
         ipaddr6 = lookupvar("ipaddress6_#{interfaces}")
         result << ipaddr if ipaddr && (ipaddr != :undefined)


### PR DESCRIPTION
When there is a docker interface created, every new docker image that gets created causes the list of detected ip addresses to be updated.  When this update occurs, and you are using exported resources, you end up causing updates on all machines that are pulling in the exported resources.

I couldn't see any reason why you would want docker IPs in this list anyway, so this patch excludes them from consideration.