### PR TITLE
Avoid exporting fe80::/64

### DIFF
--- a/lib/puppet/parser/functions/ipaddresses.rb
+++ b/lib/puppet/parser/functions/ipaddresses.rb
@@ -29,6 +29,10 @@ EOS
       end
     end
 
+    # Throw away any v6 link-local addresses
+    fe80_64 = IPAddr.new("fe80::/64")
+    result.delete_if { |ip| fe80_64.include? IPAddr.new(ip) }
+
     return result
   end
 end


### PR DESCRIPTION
Link-local addresses are only valid and unique for a single link,
generated by appending the ethernet address as the least significant
64 bits.

There are conditions where the same link-local address is used for
multiple interfaces (bonding, bridges), which leads to duplicate
address entries in the array returned by the ipaddresses function.

There is no real use case to configure SSH for link-local v6
addresses via Puppet and fe80::/64 is removed entirely from the
results.

closes #218