### PR TITLE
Add parameter for sshkey resource purging.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,16 +1,17 @@
 # Main file for puppet-ssh
 class ssh (
-  Hash    $server_options        = {},
-  Hash    $server_match_block    = {},
-  Hash    $client_options        = {},
-  Hash    $users_client_options  = {},
-  String  $version               = 'present',
-  Boolean $storeconfigs_enabled  = true,
-  Boolean $validate_sshd_file    = $::ssh::params::validate_sshd_file,
-  Boolean $use_augeas            = false,
-  Array   $server_options_absent = [],
-  Array   $client_options_absent = [],
-  Boolean $use_issue_net         = false,
+  Hash    $server_options          = {},
+  Hash    $server_match_block      = {},
+  Hash    $client_options          = {},
+  Hash    $users_client_options    = {},
+  String  $version                 = 'present',
+  Boolean $storeconfigs_enabled    = true,
+  Boolean $validate_sshd_file      = $::ssh::params::validate_sshd_file,
+  Boolean $use_augeas              = false,
+  Array   $server_options_absent   = [],
+  Array   $client_options_absent   = [],
+  Boolean $use_issue_net           = false,
+  Boolean $purge_unmanaged_sshkeys = true,
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera
@@ -59,6 +60,13 @@ class ssh (
     options              => $fin_client_options,
     use_augeas           => $use_augeas,
     options_absent       => $client_options_absent,
+  }
+
+  # If host keys are being managed, optionally purge unmanaged ones as well.
+  if ($storeconfigs_enabled and $purge_unmanaged_sshkeys) {
+    resources { 'sshkey':
+      purge => true,
+    }
   }
 
   create_resources('::ssh::client::config::user', $fin_users_client_options)

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -3,10 +3,6 @@ class ssh::knownhosts(
   Optional[String] $storeconfigs_group = undef,
 ) inherits ssh::params {
   if ($collect_enabled) {
-    resources { 'sshkey':
-      purge => true,
-    }
-
     if $storeconfigs_group {
     Sshkey <<| tag == "hostkey_${storeconfigs_group}" |>>
     } else {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -30,6 +30,10 @@ describe 'ssh', type: 'class' do
       is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd(nil)
     end
 
+    it do
+      is_expected.to contain_resources('sshkey').with_purge(true)
+    end
+
     context 'when on Debian with the validate_sshd_file setting' do
       let :facts do
         {
@@ -60,6 +64,35 @@ describe 'ssh', type: 'class' do
       it do
         is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd('/usr/sbin/sshd -tf %')
       end
+    end
+  end
+
+  standard_facts = {
+    osfamily: 'Debian',
+    interfaces: 'eth0',
+    ipaddress_eth0: '192.168.1.1',
+    ipaddress6_eth0: '::1',
+    concat_basedir: '/tmp',
+    puppetversion: '3.7.0',
+    sshdsakey: 'AAAAB3NzaC1kc3MAAACBAODCvvUUnv2imW4cfuLBWVJTLMzds89MtCUXGl3+7Gza5QYJmp7GSkKBnV8+7XI+JAmjv0RKQM1RAn7mV5UplRTtg3CYbeNkX4IakZmNJLTdL4vUyIehhaxBobpOtBaJfFewCJE1plIaWvoWfEDrShcjIUbUbJMfR8YWweIIqp9bAAAAFQCr8+KRfOUZbS9Dz1t15A/Owl61VQAAAIBr/7hNPCvjzAl5+rde6jUR5k20pxAE+z2wsaZxlhrs6ZhhplyCKIXKq4rCx4QuFVPh/c+WJRPO56iH/rSh5Y5cpT1LUk66wNJcOBPprjvDEHfQUHUmfYXzNJ2BHkRL78lfzQr52YyowV6dHfktv0VsIctm13KcMr2KQygZtV6EqgAAAIEAjNC4PRdzYpWfxu268CJDpexlhBwIkIx+ovEibtYeke55qAQcF9UWko4A1c8Wf4nLLxlQYCf501Bt5lb6GmZd0xfpg27fPIfzZPL8o+E756D3ZcNXUaLj4HPRKnwNcdAtChL2jESH3fm8PyNwBI7tV6IOjmOGpyQKtmJq3IyNgms=',
+    sshrsakey: 'AAAAB3NzaC1yc2EAAAADAQABAAABAQDzA57hAMwz6pywCgxNUcloWeNMvBo2PDPxK2RCegst+9tYaf4S3shnM9a1j2PGBoeRXTuUG6mYB32fJm6/37UUUJA4lT+8CZ3hNnDZU9aitpukkKon7RIlvY1PWO8wT4A5mEa0hfdQg6Um8KZZUs+jrB+8zMJO/X0fmleY54r/JKrP3hNcpaJpTUVQEvMmKacW7nYez/PvWKAz8d02uAOXuauGKhZ9K2AHYKlQFqJ4S1jLiduoGFWxFQ2vQybbN/O0PQQU7EZlHIjSzwoowZLzlxCKCZcKnoDsbGCtYHArbjxTb+m5e7nvsamz7TXLoY90Srmc5QGMxrLUlSvkYsm5',
+    sshecdsakey: 'AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBFDrof0LPA0hGuwODy+5uTynV7rgPJspvZo2TzykBu5mSANJvdL1z5/JS3x16/c/cDjx2lfEkRoVDnon4/NjKEM=',
+    sshed25519key: '',
+    id: 'root',
+    is_pe: false,
+    path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games'
+  }
+
+  context 'When on Debian without resource purging' do
+    let :facts do
+      standard_facts
+    end
+    let :params do
+      { 'purge_unmanaged_sshkeys' => false }
+    end
+
+    it do
+      is_expected.not_to contain_resources('sshkey')
     end
   end
 end


### PR DESCRIPTION
Hi, we'd like to use this module widely at the [Minnesota Supercomputing Institute](https://www.msi.umn.ed/), and in our tests it's working very well. The only issue we've encountered is that this module unconditionally purges `sshkey` resources, so we wouldn't be able to get it to observe a standard we use at our site for determining whether unmanaged resources should be purged on a given node. This PR makes that resource purging configurable.

It's moved to `init.pp` since `ssh::knownhosts` is included in several locations and so the new parameter can't be passed along to it.