### PR TITLE
Option to ignore interfaces in ssh::hostkeys / updated metadata.json

### DIFF
--- a/lib/puppet/parser/functions/ipaddresses.rb
+++ b/lib/puppet/parser/functions/ipaddresses.rb
@@ -4,14 +4,14 @@ module Puppet::Parser::Functions
   Special network interfaces (e.g. docker0) can be excluded by an exclude list as
   first argument for this function.
 EOS
-             ) do |_args|
+             ) do |args|
     interfaces = lookupvar('interfaces')
 
-    if _args.size == 1
-      if !_args[0].is_a?(Array)
+    if args.size == 1
+      unless args[0].is_a?(Array)
         raise(Puppet::ParseError, 'ipaddresses(): Requires first argument to be a Array')
       end
-      interfaces_exclude = _args[0]
+      interfaces_exclude = args[0]
     else
       interfaces_exclude = []
     end

--- a/lib/puppet/parser/functions/ipaddresses.rb
+++ b/lib/puppet/parser/functions/ipaddresses.rb
@@ -1,9 +1,20 @@
 module Puppet::Parser::Functions
   newfunction(:ipaddresses, type: :rvalue, doc: <<-EOS
   Returns all ip addresses of network interfaces (except lo) found by facter.
+  Special network interfaces (e.g. docker0) can be excluded by an exclude list as
+  first argument for this function.
 EOS
              ) do |_args|
     interfaces = lookupvar('interfaces')
+
+    if _args.size == 1
+      if !_args[0].is_a?(Array)
+        raise(Puppet::ParseError, 'ipaddresses(): Requires first argument to be a Array')
+      end
+      interfaces_exclude = _args[0]
+    else
+      interfaces_exclude = []
+    end
 
     # In Puppet v2.7, lookupvar returns :undefined if the variable does
     # not exist.  In Puppet 3.x, it returns nil.
@@ -15,6 +26,11 @@ EOS
       interfaces = interfaces.split(',')
       interfaces.each do |iface|
         next if iface.include?('lo')
+        skip_iface = false
+        interfaces_exclude.each do |iface_exclude|
+          skip_iface = true if iface.include?(iface_exclude)
+        end
+        next if skip_iface == true
         ipaddr = lookupvar("ipaddress_#{iface}")
         ipaddr6 = lookupvar("ipaddress6_#{iface}")
         result << ipaddr if ipaddr && (ipaddr != :undefined)

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -3,10 +3,11 @@ class ssh::hostkeys(
   Boolean          $export_ipaddresses = true,
   Optional[String] $storeconfigs_group = undef,
   Array            $extra_aliases      = [],
+  Array            $exclude_interfaces = [],
 ) {
 
   if $export_ipaddresses == true {
-    $ipaddresses  = ipaddresses()
+    $ipaddresses  = ipaddresses($exclude_interfaces)
     $host_aliases = flatten([ $::fqdn, $::hostname, $extra_aliases, $ipaddresses ])
   } else {
     $host_aliases = flatten([ $::fqdn, $::hostname, $extra_aliases])

--- a/metadata.json
+++ b/metadata.json
@@ -1,4 +1,21 @@
 {
+  "name": "saz-ssh",
+  "version": "4.0.0",
+  "author": "saz",
+  "summary": "Manage SSH client and server via Puppet.",
+  "license": "Apache-2.0",
+  "source": "git://github.com/saz/puppet-ssh.git",
+  "project_page": "https://github.com/saz/puppet-ssh",
+  "dependencies": [
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.24.0 < 6.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 2.2.0 < 6.0.0"
+    }
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat"
@@ -43,22 +60,5 @@
       "version_requirement": ">= 4.10.10 < 6.0.0"
     }
   ],
-  "name": "saz-ssh",
-  "version": "4.0.0",
-  "source": "git://github.com/saz/puppet-ssh.git",
-  "author": "saz",
-  "license": "Apache-2.0",
-  "summary": "Manage SSH client and server via Puppet.",
-  "description": "Manage SSH client and server via puppet",
-  "project_page": "https://github.com/saz/puppet-ssh",
-  "dependencies": [
-    {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.24.0 < 5.0.0"
-    },
-    {
-      "name": "puppetlabs/concat",
-      "version_requirement": ">= 2.2.0 < 5.0.0"
-    }
-  ]
+  "description": "Manage SSH client and server via puppet"
 }


### PR DESCRIPTION
- Added a parameter in ipaddresses() and ssh::hostkeys for excluding "unwanted interfaces" (fixes #254)
- Updated metadata.json (as puppetlabs-concat and puppetlabs-stdlib 5.0.0 was released recently) (fixes #224)