### PR TITLE
don't fail at deep_merge if hiera data not available

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -7,7 +7,7 @@ class ssh::client(
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera
-  $hiera_options = lookup("${module_name}::client::options", Optional[Hash], 'deep', undef)
+  $hiera_options = lookup("${module_name}::client::options", Optional[Hash], 'deep', {})
 
   $fin_options = deep_merge($hiera_options, $options)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,10 +15,10 @@ class ssh (
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera
-  $hiera_server_options = lookup("${module_name}::server_options", Optional[Hash], 'deep', undef)
-  $hiera_server_match_block = lookup("${module_name}::server_match_block", Optional[Hash], 'deep', undef)
-  $hiera_client_options = lookup("${module_name}::client_options", Optional[Hash], 'deep', undef)
-  $hiera_users_client_options = lookup("${module_name}::users_client_options", Optional[Hash], 'deep', undef)
+  $hiera_server_options = lookup("${module_name}::server_options", Optional[Hash], 'deep', {})
+  $hiera_server_match_block = lookup("${module_name}::server_match_block", Optional[Hash], 'deep', {})
+  $hiera_client_options = lookup("${module_name}::client_options", Optional[Hash], 'deep', {})
+  $hiera_users_client_options = lookup("${module_name}::users_client_options", Optional[Hash], 'deep', {})
 
   $fin_server_options = deep_merge($hiera_server_options, $server_options)
   $fin_server_match_block = deep_merge($hiera_server_match_block, $server_match_block)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -10,8 +10,8 @@ class ssh::server(
 ) inherits ssh::params {
 
   # Merge hashes from multiple layer of hierarchy in hiera
-  $hiera_options = lookup("${module_name}::server::options", Optional[Hash], 'deep', undef)
-  $hiera_match_block = lookup("${module_name}::server::match_block", Optional[Hash], 'deep', undef)
+  $hiera_options = lookup("${module_name}::server::options", Optional[Hash], 'deep', {})
+  $hiera_match_block = lookup("${module_name}::server::match_block", Optional[Hash], 'deep', {})
 
   $fin_options = deep_merge($hiera_options, $options)
   $fin_match_block = deep_merge($hiera_match_block, $match_block)


### PR DESCRIPTION
if hiera data is not available this happens...

```
# cat ssh.pp 
include ssh
# puppet apply ssh.pp 
Error: Evaluation Error: Error while evaluating a Function Call, validate_deep_hash(): Both arguments must be hashes. at /etc/puppetlabs/code/environments/vagrant/modules/ssh/manifests/init.pp:23:25 on node riskiq-base.vagrant
```

with this patch hiera lookups return an empty hash if they fail