### PR TITLE
Don't populate options which have a value of `undef` 

### DIFF
--- a/templates/options.erb
+++ b/templates/options.erb
@@ -18,22 +18,22 @@
     <%- value = v[key] -%>
     <%- if value.is_a?(Array) -%>
     <%- value.each do |a| -%>
-    <%- if a != '' -%>
+    <%- if a != '' && a != nil -%>
     <%= key %> <%= bool2str(a) %>
     <%- end -%>
     <%- end -%>
-    <%- elsif value != '' -%>
+    <%- elsif value != '' && value != nil -%>
     <%= key %> <%= bool2str(value) %>
     <%- end -%>
 <%- end -%>
 <%- else -%>
 <%- if v.is_a?(Array) -%>
 <%- v.each do |a| -%>
-<%- if a != '' -%>
+<%- if a != '' && a != nil -%>
 <%= k %> <%= bool2str(a) %>
 <%- end -%>
 <%- end -%>
-<%- elsif v != :undef and v != '' -%>
+<%- elsif v != nil and v != '' -%>
 <%= k %> <%= bool2str(v) %>
 <%- end -%>
 <%- end -%>

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -42,22 +42,22 @@ ListenAddress <%= listen %>
     <%- value = v[key] -%>
     <%- if value.is_a?(Array) -%>
     <%- value.each do |a| -%>
-    <%- if a != '' -%>
+    <%- if a != '' && a != nil -%>
     <%= key %> <%= bool2str(a) %>
     <%- end -%>
     <%- end -%>
-    <%- elsif value != '' -%>
+    <%- elsif value != '' && value != nil -%>
     <%= key %> <%= bool2str(value) %>
     <%- end -%>
 <%- end -%>
 <%- else -%>
 <%- if v.is_a?(Array) -%>
 <%- v.each do |a| -%>
-<%- if a != '' -%>
+<%- if a != '' && a != nil -%>
 <%= k %> <%= bool2str(a) %>
 <%- end -%>
 <%- end -%>
-<%- elsif v != :undef and v != '' -%>
+<%- elsif v != nil and v != '' -%>
 <%= k %> <%= bool2str(v) %>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Currently if you have
```
HostKeys => undef,
MACs      => undef,
Ciphers    => 'md5',
```
The module will add the Key with a '' value into the config file
```
HostKeys
MACs
Ciphers md5
```
This is because Puppet `undef` turns into Ruby `NIL` which is different from an empty string `''` so an added `&& v != nil` is required to prevent empty values. I'm not sure if there are any sshd config options that required/would have an empty value that this change would break. 