### PR TITLE
Sort hostkeys

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -10,9 +10,9 @@ class ssh::hostkeys(
   if $export_ipaddresses == true {
     $ipaddresses = ssh::ipaddresses($exclude_interfaces)
     $ipaddresses_real = $ipaddresses - $exclude_ipaddresses
-    $host_aliases = unique(flatten([ $::fqdn, $::hostname, $extra_aliases, $ipaddresses_real ]))
+    $host_aliases = sort(unique(flatten([ $::fqdn, $::hostname, $extra_aliases, $ipaddresses_real ])))
   } else {
-    $host_aliases = unique(flatten([ $::fqdn, $::hostname, $extra_aliases]))
+    $host_aliases = sort(unique(flatten([ $::fqdn, $::hostname, $extra_aliases])))
   }
 
   if $storeconfigs_group {


### PR DESCRIPTION
This avoids reloads of hostkeys after Puppet runs.