### PR TITLE
Use gid 0 instead of group name for $host_priv_key_group

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,7 +9,7 @@ class ssh::params {
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       $service_name = 'ssh'
       $sftp_server_path = '/usr/lib/openssh/sftp-server'
-      $host_priv_key_group = 'root'
+      $host_priv_key_group = 0
     }
     'RedHat': {
       $server_package_name = 'openssh-server'
@@ -23,7 +23,7 @@ class ssh::params {
       if versioncmp($::operatingsystemmajrelease, '7') >= 0 {
         $host_priv_key_group = 'ssh_keys'
       } else {
-        $host_priv_key_group = 'root'
+        $host_priv_key_group = 0
       }
     }
     'FreeBSD', 'DragonFly': {
@@ -35,7 +35,7 @@ class ssh::params {
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       $service_name = 'sshd'
       $sftp_server_path = '/usr/libexec/sftp-server'
-      $host_priv_key_group = 'root'
+      $host_priv_key_group = 0
     }
     'OpenBSD': {
       $server_package_name = undef
@@ -46,7 +46,7 @@ class ssh::params {
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       $service_name = 'sshd'
       $sftp_server_path = '/usr/libexec/sftp-server'
-      $host_priv_key_group = 'root'
+      $host_priv_key_group = 0
     }
     'Darwin': {
       $server_package_name = undef
@@ -57,7 +57,7 @@ class ssh::params {
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       $service_name = 'com.openssh.sshd'
       $sftp_server_path = '/usr/libexec/sftp-server'
-      $host_priv_key_group = 'root'
+      $host_priv_key_group = 0
     }
     'ArchLinux': {
       $server_package_name = 'openssh'
@@ -68,7 +68,7 @@ class ssh::params {
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
       $service_name = 'sshd.service'
       $sftp_server_path = '/usr/lib/ssh/sftp-server'
-      $host_priv_key_group = 'root'
+      $host_priv_key_group = 0
     }
     'Suse': {
       $server_package_name = 'openssh'
@@ -77,7 +77,7 @@ class ssh::params {
       $sshd_config = '/etc/ssh/sshd_config'
       $ssh_config = '/etc/ssh/ssh_config'
       $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
-      $host_priv_key_group = 'root'
+      $host_priv_key_group = 0
       case $::operatingsystem {
         'SLES': {
           $service_name = 'sshd'
@@ -115,7 +115,7 @@ class ssh::params {
           $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
           $service_name = 'svc:/network/ssh:default'
           $sftp_server_path = 'internal-sftp'
-          $host_priv_key_group = 'root'
+          $host_priv_key_group = 0
         }
         default: {
           $sshd_dir = '/etc/ssh'
@@ -124,7 +124,7 @@ class ssh::params {
           $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
           $service_name = 'svc:/network/ssh:default'
           $sftp_server_path = 'internal-sftp'
-          $host_priv_key_group = 'root'
+          $host_priv_key_group = 0
           case versioncmp($::kernelrelease, '5.10') {
             1: {
               # Solaris 11 and later
@@ -155,7 +155,7 @@ class ssh::params {
           $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
           $service_name = 'sshd'
           $sftp_server_path = '/usr/lib/misc/sftp-server'
-          $host_priv_key_group = 'root'
+          $host_priv_key_group = 0
         }
         'Amazon': {
           $server_package_name = 'openssh-server'
@@ -166,7 +166,7 @@ class ssh::params {
           $ssh_known_hosts = '/etc/ssh/ssh_known_hosts'
           $service_name = 'sshd'
           $sftp_server_path = '/usr/libexec/openssh/sftp-server'
-          $host_priv_key_group = 'root'
+          $host_priv_key_group = 0
         }
         default: {
           fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")

--- a/spec/defines/server/host_key_spec.rb
+++ b/spec/defines/server/host_key_spec.rb
@@ -35,7 +35,7 @@ describe 'ssh::server::host_key', type: :define do
         with_content('bcd').
         with_ensure('present').
         with_owner(0).
-        with_group('root').
+        with_group(0).
         with_mode('0600').
         with_path('/etc/ssh/something')
       is_expected.to contain_file('something_cert').
@@ -68,7 +68,7 @@ describe 'ssh::server::host_key', type: :define do
         with_content('bcd').
         with_ensure('present').
         with_owner(0).
-        with_group('root').
+        with_group(0).
         with_mode('0600').
         with_path('/etc/ssh/something')
       is_expected.not_to contain_file('something_cert')
@@ -99,7 +99,7 @@ describe 'ssh::server::host_key', type: :define do
         with_source('b').
         with_ensure('present').
         with_owner(0).
-        with_group('root').
+        with_group(0).
         with_mode('0600').
         with_path('/etc/ssh/something')
       is_expected.not_to contain_file('something_cert')


### PR DESCRIPTION
FreeBSD 12 does not have a group root, the name of gid 0 is 'wheel'.