### PR TITLE
Allow filtering ipaddress interfaces with regexps

### DIFF
--- a/lib/puppet/functions/ssh/ipaddresses.rb
+++ b/lib/puppet/functions/ssh/ipaddresses.rb
@@ -35,6 +35,6 @@ Puppet::Functions.create_function(:'ssh::ipaddresses') do
     fe8064 = IPAddr.new('fe80::/64')
     result.delete_if { |ip| fe8064.include? IPAddr.new(ip) }
 
-    result.uniq
+    result.uniq.sort
   end
 end

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -4,12 +4,12 @@
 # @api private
 #
 class ssh::hostkeys(
-  Boolean          $export_ipaddresses  = true,
-  Optional[String] $storeconfigs_group  = undef,
-  Array            $extra_aliases       = [],
-  Array            $exclude_interfaces  = [],
-  Array            $exclude_ipaddresses = [],
-  Boolean          $use_trusted_facts   = false,
+  Boolean                        $export_ipaddresses  = true,
+  Optional[String]               $storeconfigs_group  = undef,
+  Array                          $extra_aliases       = [],
+  Array[Variant[String, Regexp]] $exclude_interfaces  = [],
+  Array                          $exclude_ipaddresses = [],
+  Boolean                        $use_trusted_facts   = false,
 ) {
 
   if $use_trusted_facts {
@@ -20,7 +20,7 @@ class ssh::hostkeys(
     $hostname_real = $facts['networking']['hostname']
   }
 
-  if $export_ipaddresses == true {
+  if $export_ipaddresses {
     $ipaddresses = ssh::ipaddresses($exclude_interfaces)
     $ipaddresses_real = $ipaddresses - $exclude_ipaddresses
     $host_aliases = sort(unique(flatten([ $fqdn_real, $hostname_real, $extra_aliases, $ipaddresses_real ])))

--- a/spec/fixtures/mock-interface-fact.json
+++ b/spec/fixtures/mock-interface-fact.json
@@ -83,6 +83,86 @@
         "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
         "network": "127.0.0.0",
         "network6": "::1"
+      },
+      "br-bf9119c86ea6": {
+        "bindings": [
+          {
+            "address": "172.26.0.1",
+            "netmask": "255.255.0.0",
+            "network": "172.26.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::42:2cff:fe68:c503",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "ip": "172.26.0.1",
+        "ip6": "fe80::42:2cff:fe68:c503",
+        "mac": "01:02:2c:68:09:0a",
+        "mtu": 1500,
+        "netmask": "255.255.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "172.26.0.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      },
+      "docker_gwbridge": {
+        "bindings": [
+          {
+            "address": "172.19.0.1",
+            "netmask": "255.255.0.0",
+            "network": "172.19.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::42:dbff:fee2:7c4e",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "ip": "172.19.0.1",
+        "ip6": "fe80::42:dbff:fee2:7c4e",
+        "mac": "01:02:db:e2:07:08",
+        "mtu": 1500,
+        "netmask": "255.255.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "172.19.0.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      },
+      "veth3a43276": {
+        "bindings6": [
+          {
+            "address": "fe80::8e1:37ff:fe75:4597",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "ip6": "fe80::8e1:37ff:fe75:4597",
+        "mac": "01:02:37:75:05:06",
+        "mtu": 1500,
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network6": "fe80::",
+        "scope6": "link"
+      },
+      "veth408ad02": {
+        "bindings6": [
+          {
+            "address": "fe80::9c97:d6ff:fe5d:46af",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "ip6": "fe80::9c97:d6ff:fe5d:46af",
+        "mac": "01:02:d6:5d:03:04",
+        "mtu": 1500,
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network6": "fe80::",
+        "scope6": "link"
       }
     }
   }

--- a/spec/functions/ssh/ipaddresses_spec.rb
+++ b/spec/functions/ssh/ipaddresses_spec.rb
@@ -12,18 +12,32 @@ describe 'ssh::ipaddresses', type: :puppet_function do
 
     describe 'without parameters' do
       it 'returns all IPs other than localhost' do
-        is_expected.to run.and_return(['172.17.0.1', '10.13.42.61', '10.0.0.110', '10.0.0.104', '10.0.0.109'])
+        is_expected.
+          to run.
+               and_return(['10.0.0.104',
+                           '10.0.0.109',
+                           '10.0.0.110',
+                           '10.13.42.61',
+                           '172.17.0.1',
+                           '172.19.0.1',
+                           '172.26.0.1'])
       end
     end
 
     describe 'with excluded interface' do
       it 'doesn\'t return the IPs of excluded interface' do
-        is_expected.to run.with_params(['docker0']).and_return(['10.13.42.61', '10.0.0.110', '10.0.0.104', '10.0.0.109'])
+        is_expected.
+          to run.
+               with_params(['docker0', /^br-/, /^docker_/]).
+               and_return(['10.0.0.104',
+                           '10.0.0.109',
+                           '10.0.0.110',
+                           '10.13.42.61'])
       end
     end
     describe 'with excluded interfaces' do
       it 'doesn\'t return the IPs of those interfaces' do
-        is_expected.to run.with_params(%w[docker0 eno1]).and_return([])
+        is_expected.to run.with_params(%w[docker0 eno1]).and_return(['172.19.0.1', '172.26.0.1'])
       end
     end
   end


### PR DESCRIPTION
This PR allows users to filter exported IP addresses by using regexp matching of
interface names. This is particularly handy if your servers run Docker or
another service which creates bridge or virtual interfaces with arbitrary IP
addresses, resulting in constantly changing known hosts.

The documented way of setting `exclude_interfaces` uses Hiera, but from Hiera
it's not possible to return a `Regexp` type value without hackery. Instead I've
used it like so:

``` puppet
class { 'ssh':
  storeconfigs_enabled => false,
}

include ssh::knownhosts

Class['ssh::server::service']
-> Class['ssh::hostkeys']
-> Class['ssh::knownhosts']
-> Anchor['ssh::server::end']

class { 'ssh::hostkeys':
  exclude_interfaces => [
    /^br-[0-9a-f]+$/,
    /^docker[0-9]+$/,
    /^docker_/,
    /^veth[0-9a-f]+$/
  ],
}
```

Another option would be to have the `ssh::hostkeys` class (or the `ipaddresses`
function) automatically coerce strings to regular expressions if they match
`/^\/.+\/$/`.