### PR TITLE
Fixing support for 5.5 agents

### DIFF
--- a/lib/puppet/functions/ssh/ipaddresses.rb
+++ b/lib/puppet/functions/ssh/ipaddresses.rb
@@ -18,15 +18,17 @@ Puppet::Functions.create_function(:'ssh::ipaddresses') do
     excluded_interfaces += ['lo']
 
     result = []
-    facts['networking']['interfaces'].each do |iface, data|
-      # skip excluded interfaces
-      next if excluded_interfaces.include?(iface)
+    if facts['networking']
+      facts['networking']['interfaces'].each do |iface, data|
+        # skip excluded interfaces
+        next if excluded_interfaces.include?(iface)
 
-      %w[bindings bindings6].each do |binding_type|
-        next unless data.key?(binding_type)
-        data[binding_type].each do |binding|
-          next unless binding.key?('address')
-          result << binding['address']
+        %w[bindings bindings6].each do |binding_type|
+          next unless data.key?(binding_type)
+          data[binding_type].each do |binding|
+            next unless binding.key?('address')
+            result << binding['address']
+          end
         end
       end
     end

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -21,7 +21,7 @@ class ssh::hostkeys(
   }
 
   if $export_ipaddresses == true {
-    $ipaddresses = ssh::ipaddresses($exclude_interfaces)
+    $ipaddresses = ipaddresses($exclude_interfaces)
     $ipaddresses_real = $ipaddresses - $exclude_ipaddresses
     $host_aliases = sort(unique(flatten([ $fqdn_real, $hostname_real, $extra_aliases, $ipaddresses_real ])))
   } else {

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -15,13 +15,16 @@ class ssh::hostkeys(
   if $use_trusted_facts {
     $fqdn_real = $trusted['certname']
     $hostname_real = $trusted['hostname']
+  } elsif versioncmp('6.0.0', $facts['puppetversion']) >= 0 {
+    $fqdn_real = $facts['fqdn']
+    $hostname_real = $facts['hostname']
   } else {
     $fqdn_real = $facts['networking']['fqdn']
     $hostname_real = $facts['networking']['hostname']
   }
 
   if $export_ipaddresses == true {
-    $ipaddresses = ipaddresses($exclude_interfaces)
+    $ipaddresses = ssh::ipaddresses($exclude_interfaces)
     $ipaddresses_real = $ipaddresses - $exclude_ipaddresses
     $host_aliases = sort(unique(flatten([ $fqdn_real, $hostname_real, $extra_aliases, $ipaddresses_real ])))
   } else {


### PR DESCRIPTION
With the current code the 5.5 agents fail to compile with this error:
`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, undefined method `[]' for nil:NilClass (file: /etc/puppetlabs/code/environments/dev/modules/ssh/manifests/hostkeys.pp, line: 24, column: 20) on node dprpi1-1`

This PR resolves this and it still works on the 6.x agents I have running.