### PR TITLE
Update sshd_config

### DIFF
--- a/files/sshd_config
+++ b/files/sshd_config
@@ -10,8 +10,6 @@ Protocol 2
 # HostKeys for protocol version 2
 HostKey /etc/ssh/ssh_host_rsa_key
 HostKey /etc/ssh/ssh_host_dsa_key
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
 
 # Lifetime and size of ephemeral version 1 server key
 KeyRegenerationInterval 3600


### PR DESCRIPTION
deletion of deprecated option : UsePrivilegeSeparation in Ubuntu 20.04 sshd