### PR TITLE
Allow stdlib 8.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.0 < 8.0.0"
+      "version_requirement": ">= 4.25.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
A new major version of stdlib was released.

Some modules from voxpupuli depend on this module and required a new release of it allowing that latest version of stdlib.

Thanks!