### PR TITLE
hostkeys.pp: remove "@api private" marking

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -1,8 +1,6 @@
 # @summary
 #   This class manages hostkeys
 #
-# @api private
-#
 class ssh::hostkeys (
   Boolean          $export_ipaddresses  = true,
   Optional[String] $storeconfigs_group  = undef,


### PR DESCRIPTION
This does not appear to be a private API. There is no other "public API" way to supply arguments to this class.