### PR TITLE
metadata.json: Use https URL to git repo

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "summary": "Manage SSH client and server via Puppet.",
   "description": "Manage SSH client and server via puppet",
   "license": "Apache-2.0",
-  "source": "git://github.com/saz/puppet-ssh.git",
+  "source": "https://github.com/saz/puppet-ssh.git",
   "project_page": "https://github.com/saz/puppet-ssh",
   "dependencies": [
     {


### PR DESCRIPTION
using plaintext git URLs isn't supported by GitHub anymore. People might
parse the metadata.json to get the git URL which will then fail.