### PR TITLE
Fix duplicate declaration when the server class is directly used

### DIFF
--- a/manifests/server/match_block.pp
+++ b/manifests/server/match_block.pp
@@ -9,7 +9,8 @@ define ssh::server::match_block (
   Integer $order = 50,
   Stdlib::Absolutepath $target = $ssh::params::sshd_config,
 ) {
-  include ssh
+
+  include ssh::server
   if $ssh::server::use_augeas {
     fail('ssh::server::match_block() define not supported with use_augeas = true')
   } else {

--- a/manifests/server/match_block.pp
+++ b/manifests/server/match_block.pp
@@ -7,7 +7,7 @@ define ssh::server::match_block (
   Hash $options  = {},
   String $type   = 'user',
   Integer $order = 50,
-  Stdlib::Absolutepath $target = $ssh::params::sshd_config,
+  Optional[Stdlib::Absolutepath] $target = undef,
 ) {
 
   include ssh::server
@@ -15,7 +15,7 @@ define ssh::server::match_block (
     fail('ssh::server::match_block() define not supported with use_augeas = true')
   } else {
     concat::fragment { "match_block ${name}":
-      target  => $target,
+      target  => pick($target, $ssh::params::sshd_config),
       content => template("${module_name}/sshd_match_block.erb"),
       order   => 200+$order,
     }


### PR DESCRIPTION
... with ssh::match_block, caused by the following references.
 ssh::server::match_block -> ssh -> ssh::server

This also ensures the params class is loaded when picking up its
variable to determine the default value.