### PR TITLE
Fix sshd_config parameter lookup

### DIFF
--- a/manifests/server/match_block.pp
+++ b/manifests/server/match_block.pp
@@ -5,7 +5,7 @@ define ssh::server::match_block (
   Hash $options  = {},
   String $type   = 'user',
   Integer $order = 50,
-  Stdlib::Absolutepath $target = $ssh::params::sshd_config,
+  Stdlib::Absolutepath $target = $ssh::sshd_config,
 ) {
   if $ssh::server::use_augeas {
     fail('ssh::server::match_block() define not supported with use_augeas = true')


### PR DESCRIPTION
A reference to ssh::params was missed as part of de847bda70d6824a73469da7780e1b3582816165