### PR TITLE
fix parameter lookup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :test do
-  gem 'voxpupuli-test', '~> 2.5',   :require => false
+  gem 'voxpupuli-test', '~> 5.0',   :require => false
   gem 'coveralls',                  :require => false
   gem 'simplecov-console',          :require => false
   gem 'puppet_metadata', '~> 1.0',  :require => false
@@ -21,7 +21,7 @@ end
 
 group :release do
   gem 'github_changelog_generator', '>= 1.16.1',  :require => false
-  gem 'voxpupuli-release', '>= 1.0.2',            :require => false
+  gem 'voxpupuli-release', '>= 1.2.0',            :require => false
   gem 'puppet-strings', '>= 2.2',                 :require => false
 end
 

--- a/data/Amazon.yaml
+++ b/data/Amazon.yaml
@@ -1,12 +1,11 @@
 ---
-ssh::server_package_name: 'openssh-server'
-ssh::client_package_name: 'openssh-clients'
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_binary: '/usr/sbin/sshd'
-ssh::sshd_environments_file: '/etc/sysconfig/sshd'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'sshd'
+ssh::server::server_package_name: 'openssh-server'
+ssh::client::client_package_name: 'openssh-clients'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/sbin/sshd'
+ssh::server::sshd_environments_file: '/etc/sysconfig/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/openssh/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/Archlinux.yaml
+++ b/data/Archlinux.yaml
@@ -1,11 +1,10 @@
 ---
-ssh::server_package_name: 'openssh'
-ssh::client_package_name: 'openssh'
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_binary: '/usr/bin/sshd'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'sshd.service'
+ssh::server::server_package_name: 'openssh'
+ssh::client::client_package_name: 'openssh'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/bin/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'sshd.service'
 ssh::sftp_server_path: '/usr/lib/ssh/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -1,8 +1,7 @@
 ---
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'com.openssh.sshd'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'com.openssh.sshd'
 ssh::sftp_server_path: '/usr/libexec/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,12 +1,11 @@
 ---
-ssh::server_package_name: 'openssh-server'
-ssh::client_package_name: 'openssh-client'
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_binary: '/usr/sbin/sshd'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::sshd_environments_file: '/etc/default/ssh'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'ssh'
+ssh::server::server_package_name: 'openssh-server'
+ssh::client::client_package_name: 'openssh-client'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/sbin/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::server::sshd_environments_file: '/etc/default/ssh'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'ssh'
 ssh::sftp_server_path: '/usr/lib/openssh/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/DragonFly.yaml
+++ b/data/DragonFly.yaml
@@ -1,9 +1,8 @@
 ---
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_binary: '/usr/local/sbin/sshd'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'sshd'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/local/sbin/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/FreeBSD.yaml
+++ b/data/FreeBSD.yaml
@@ -1,9 +1,8 @@
 ---
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_binary: '/usr/local/sbin/sshd'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'sshd'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/local/sbin/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/Gentoo.yaml
+++ b/data/Gentoo.yaml
@@ -1,11 +1,10 @@
 ---
-ssh::server_package_name: 'openssh'
-ssh::client_package_name: 'openssh'
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_binary: '/usr/sbin/sshd'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'sshd'
+ssh::server::server_package_name: 'openssh'
+ssh::client::client_package_name: 'openssh'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/sbin/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/lib64/misc/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/OpenBSD.yaml
+++ b/data/OpenBSD.yaml
@@ -1,20 +1,19 @@
 ---
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'sshd'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0
 
-ssh::server_options:
+ssh::server::default_options:
   ChallengeResponseAuthentication: 'no'
   X11Forwarding                  : 'yes'
   PrintMotd                      : 'no'
   AcceptEnv                      : 'LANG LC_*'
   Subsystem                      : "sftp %{lookup('ssh::sftp_server_path')}"
 
-ssh::client_options:
+ssh::client::default_options:
   'Host *':
     SendEnv: 'LANG LC_*'
     HashKnownHosts: 'yes'

--- a/data/OpenSuSE.yaml
+++ b/data/OpenSuSE.yaml
@@ -1,3 +1,3 @@
 ---
-ssh::service_name: 'sshd'
+ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/lib/ssh/sftp-server'

--- a/data/RedHat-7.yaml
+++ b/data/RedHat-7.yaml
@@ -1,2 +1,2 @@
 ---
-ssh::host_priv_key_group: 'ssh_keys'
+ssh::server::host_priv_key_group: 'ssh_keys'

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,12 +1,11 @@
 ---
-ssh::server_package_name: 'openssh-server'
-ssh::client_package_name: 'openssh-clients'
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_binary: '/usr/sbin/sshd'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::sshd_environments_file: '/etc/sysconfig/sshd'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'sshd'
+ssh::server::server_package_name: 'openssh-server'
+ssh::client::client_package_name: 'openssh-clients'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/sbin/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::server::sshd_environments_file: '/etc/sysconfig/sshd'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/openssh/sftp-server'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/SLES.yaml
+++ b/data/SLES.yaml
@@ -1,3 +1,3 @@
 ---
-ssh::service_name: 'sshd'
+ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/lib/ssh/sftp-server'

--- a/data/SmartOS.yaml
+++ b/data/SmartOS.yaml
@@ -1,8 +1,7 @@
 ---
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'svc:/network/ssh:default'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'svc:/network/ssh:default'
 ssh::sftp_server_path: 'internal-sftp'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0

--- a/data/Solaris-10.yaml
+++ b/data/Solaris-10.yaml
@@ -1,3 +1,3 @@
 ---
-ssh::server_package_name: 'SUNWsshdu'
-ssh::client_package_name: 'SUNWsshu'
+ssh::server::server_package_name: 'SUNWsshdu'
+ssh::client::client_package_name: 'SUNWsshu'

--- a/data/Solaris.yaml
+++ b/data/Solaris.yaml
@@ -1,16 +1,17 @@
 ---
-ssh::server_package_name: '/service/network/ssh'
-ssh::client_package_name: '/network/ssh'
-ssh::sshd_binary: '/lib/svc/method/sshd'
-ssh::ssh::service_name: 'svc:/network/ssh:default'
+ssh::server::server_package_name: '/service/network/ssh'
+ssh::client::client_package_name: '/network/ssh'
+ssh::server::sshd_binary: '/lib/svc/method/sshd'
+ssh::server::service_name: 'svc:/network/ssh:default'
+ssh::sftp_server_path: 'internal-sftp'
 
-ssh:sshd_default_options:
+ssh::server::default_options:
   ChallengeResponseAuthentication: 'no'
   X11Forwarding: 'yes'
   PrintMotd: 'no'
   Subsystem: "sftp %{lookup('ssh::sftp_server_path')}"
   HostKey:
-    - "%{lookup('ssh::sshd_dir')}/ssh_host_rsa_key"
-    - "%{lookup('ssh::sshd_dir')}/ssh_host_dsa_key"
-
-ssh::client_options: {}
+    - "%{lookup('ssh::server::sshd_dir')}/ssh_host_rsa_key"
+    - "%{lookup('ssh::server::sshd_dir')}/ssh_host_dsa_key"
+  
+ssh::client::default_options: {}

--- a/data/Suse.yaml
+++ b/data/Suse.yaml
@@ -1,10 +1,9 @@
 ---
-ssh::server_package_name: 'openssh'
-ssh::client_package_name: 'openssh'
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_binary: '/usr/sbin/sshd'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::sshd_environments_file: '/etc/sysconfig/ssh'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::host_priv_key_group: 0
+ssh::server::server_package_name: 'openssh'
+ssh::client::client_package_name: 'openssh'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/sbin/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::server::sshd_environments_file: '/etc/sysconfig/ssh'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::host_priv_key_group: 0

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -8,21 +8,23 @@ lookup_options:
     merge: deep
   ssh::users_client_options:
     merge: deep
+  ssh::server::options:
+    merge: deep
+  ssh::client::options:
+    merge: deep
 
-ssh::sshd_dir: '/etc/ssh'
-ssh::sshd_config: '/etc/ssh/sshd_config'
-ssh::ssh_config: '/etc/ssh/ssh_config'
-ssh::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
-ssh::service_name: 'svc:/network/ssh:default'
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::client::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::service_name: 'svc:/network/ssh:default'
 ssh::sftp_server_path: 'internal-sftp'
-ssh::host_priv_key_group: 0
+ssh::server::host_priv_key_group: 0
 ssh::validate_sshd_file             : false
-ssh::user_ssh_directory_default_mode: '0700'
-ssh::user_ssh_config_default_mode   : '0600'
 ssh::collect_enabled                : true   # Collect sshkey resources
-ssh::issue_net                      : '/etc/issue.net'
+ssh::server::issue_net              : '/etc/issue.net'
+ssh::knownhosts::collect_enabled    : true
 
-ssh::server_options:
+ssh::server::default_options:
   ChallengeResponseAuthentication: 'no'
   X11Forwarding: 'yes'
   PrintMotd: 'no'
@@ -30,7 +32,7 @@ ssh::server_options:
   Subsystem: "sftp %{lookup('ssh::sftp_server_path')}"
   UsePAM: 'yes'
 
-ssh::client_options:
+ssh::client::default_options:
   'Host *':
     SendEnv: 'LANG LC_*'
     HashKnownHosts: 'yes'

--- a/lib/facter/ssh_client_version.rb
+++ b/lib/facter/ssh_client_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Facter.add('ssh_client_version_full') do
   confine kernel: %w[Linux SunOS FreeBSD DragonFly Darwin]
 
@@ -10,7 +12,7 @@ Facter.add('ssh_client_version_full') do
                 first.
                 rstrip
 
-      version.gsub(%r{^(OpenSSH_|Sun_SSH_)([^ ,]+).*$}, '\2') unless version.nil?
+      version&.gsub(%r{^(OpenSSH_|Sun_SSH_)([^ ,]+).*$}, '\2')
     end
   end
 end
@@ -21,7 +23,7 @@ Facter.add('ssh_client_version_major') do
   setcode do
     version = Facter.value('ssh_client_version_full')
 
-    version.gsub(%r{^([0-9]+\.[0-9]+).*$}, '\1') unless version.nil?
+    version&.gsub(%r{^([0-9]+\.[0-9]+).*$}, '\1')
   end
 end
 
@@ -31,6 +33,6 @@ Facter.add('ssh_client_version_release') do
   setcode do
     version = Facter.value('ssh_client_version_full')
 
-    version.gsub(%r{^([0-9]+\.[0-9]+(?:\.[0-9]+)?).*$}, '\1') unless version.nil?
+    version&.gsub(%r{^([0-9]+\.[0-9]+(?:\.[0-9]+)?).*$}, '\1')
   end
 end

--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Facter.add('ssh_server_version_full') do
   confine kernel: %w[Linux SunOS FreeBSD DragonFly Darwin]
 
@@ -13,7 +15,7 @@ Facter.add('ssh_server_version_full') do
                 first.
                 rstrip
 
-      version.gsub(%r{^(OpenSSH_|Sun_SSH_)([^ ,]+).*$}, '\2') unless version.nil?
+      version&.gsub(%r{^(OpenSSH_|Sun_SSH_)([^ ,]+).*$}, '\2')
     end
   end
 end
@@ -40,6 +42,6 @@ Facter.add('ssh_server_version_release') do
   setcode do
     version = Facter.value('ssh_server_version_full')
 
-    version.gsub(%r{^([0-9]+\.[0-9]+(?:\.[0-9]+)?).*$}, '\1') unless version.nil?
+    version&.gsub(%r{^([0-9]+\.[0-9]+(?:\.[0-9]+)?).*$}, '\1')
   end
 end

--- a/lib/puppet/functions/ssh/ipaddresses.rb
+++ b/lib/puppet/functions/ssh/ipaddresses.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @summary Returns ip addresses of network interfaces (except lo) found by facter.
 # @api private
 #
@@ -23,13 +25,10 @@ Puppet::Functions.create_function(:'ssh::ipaddresses') do
       interfaces = {}
       facts['interfaces'].split(',').each do |iface|
         next if facts["ipaddress_#{iface}"].nil? && facts["ipaddress6_#{iface}"].nil?
+
         interfaces[iface] = {}
-        if !facts["ipaddress_#{iface}"].nil? && !facts["ipaddress_#{iface}"].empty?
-          interfaces[iface]['bindings'] = [{ 'address' => facts["ipaddress_#{iface}"] }]
-        end
-        if !facts["ipaddress6_#{iface}"].nil? && !facts["ipaddress6_#{iface}"].empty?
-          interfaces[iface]['bindings6'] = [{ 'address' => facts["ipaddress6_#{iface}"] }]
-        end
+        interfaces[iface]['bindings'] = [{ 'address' => facts["ipaddress_#{iface}"] }] if !facts["ipaddress_#{iface}"].nil? && !facts["ipaddress_#{iface}"].empty?
+        interfaces[iface]['bindings6'] = [{ 'address' => facts["ipaddress6_#{iface}"] }] if !facts["ipaddress6_#{iface}"].nil? && !facts["ipaddress6_#{iface}"].empty?
       end
     end
 
@@ -40,8 +39,10 @@ Puppet::Functions.create_function(:'ssh::ipaddresses') do
 
       %w[bindings bindings6].each do |binding_type|
         next unless data.key?(binding_type)
+
         data[binding_type].each do |binding|
           next unless binding.key?('address')
+
           result << binding['address']
         end
       end

--- a/lib/puppet/parser/functions/sshclient_options_to_augeas_ssh_config.rb
+++ b/lib/puppet/parser/functions/sshclient_options_to_augeas_ssh_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puppet::Parser::Functions
   newfunction(:sshclient_options_to_augeas_ssh_config, type: :rvalue, doc: <<-'DOC') do |args|
   This function will convert a key-value hash to a format understandable by the augeas sshd_config provider
@@ -66,27 +68,15 @@ module Puppet::Parser::Functions
 
   DOC
 
-    if args.empty?
-      raise Puppet::ParseError, 'sshclient_options_to_augeas_ssh_config: expects at least one argument'
-    end
+    raise Puppet::ParseError, 'sshclient_options_to_augeas_ssh_config: expects at least one argument' if args.empty?
 
     options = args[0]
-    unless options.is_a?(Hash)
-      raise Puppet::ParseError, 'sshclient_options_to_augeas_ssh_config: first argument must be a hash'
-    end
+    raise Puppet::ParseError, 'sshclient_options_to_augeas_ssh_config: first argument must be a hash' unless options.is_a?(Hash)
 
     options_absent = args[1] if args[1]
     other_parameters = args[2] if args[2]
-    if options_absent
-      unless options_absent.is_a?(Array) || options_absent.is_a?(String)
-        raise Puppet::ParseError, 'sshclient_options_to_augeas_ssh_config: second argument, if supplied, must be an array or a string'
-      end
-    end
-    if other_parameters
-      unless other_parameters.is_a?(Hash)
-        raise Puppet::ParseError, 'sshclient_options_to_augeas_ssh_config: third argument, if supplied, must be a hash'
-      end
-    end
+    raise Puppet::ParseError, 'sshclient_options_to_augeas_ssh_config: second argument, if supplied, must be an array or a string' if options_absent && !(options_absent.is_a?(Array) || options_absent.is_a?(String))
+    raise Puppet::ParseError, 'sshclient_options_to_augeas_ssh_config: third argument, if supplied, must be a hash' if other_parameters && !other_parameters.is_a?(Hash)
 
     options_final_augeas = {}
     options.each do |key1, value1|

--- a/lib/puppet/parser/functions/sshserver_options_to_augeas_sshd_config.rb
+++ b/lib/puppet/parser/functions/sshserver_options_to_augeas_sshd_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Puppet::Parser::Functions
   newfunction(:sshserver_options_to_augeas_sshd_config, type: :rvalue, doc: <<-'DOC') do |args|
   This function will convert a key-value hash to a format understandable by the augeas sshd_config provider
@@ -76,27 +78,15 @@ module Puppet::Parser::Functions
 
   DOC
 
-    if args.empty?
-      raise Puppet::ParseError, 'sshserver_options_to_augeas_sshd_config: expects at least one argument'
-    end
+    raise Puppet::ParseError, 'sshserver_options_to_augeas_sshd_config: expects at least one argument' if args.empty?
 
     options = args[0]
-    unless options.is_a?(Hash)
-      raise Puppet::ParseError, 'sshserver_options_to_augeas_sshd_config: first argument must be a hash'
-    end
+    raise Puppet::ParseError, 'sshserver_options_to_augeas_sshd_config: first argument must be a hash' unless options.is_a?(Hash)
 
     options_absent = args[1] if args[1]
     other_parameters = args[2] if args[2]
-    if options_absent
-      unless options_absent.is_a?(Array) || options_absent.is_a?(String)
-        raise Puppet::ParseError, 'sshserver_options_to_augeas_sshd_config: second argument, if supplied, must be an array or a string'
-      end
-    end
-    if other_parameters
-      unless other_parameters.is_a?(Hash)
-        raise Puppet::ParseError, 'sshserver_options_to_augeas_sshd_config: third argument, if supplied, must be a hash'
-      end
-    end
+    raise Puppet::ParseError, 'sshserver_options_to_augeas_sshd_config: second argument, if supplied, must be an array or a string' if options_absent && !(options_absent.is_a?(Array) || options_absent.is_a?(String))
+    raise Puppet::ParseError, 'sshserver_options_to_augeas_sshd_config: third argument, if supplied, must be a hash' if other_parameters && !other_parameters.is_a?(Hash)
 
     options_final_augeas = {}
     options.each do |key1, value1|

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -1,11 +1,18 @@
+# @summary
+#   Manages ssh configuration
+#
+# @api private
+#
 class ssh::client::config {
+  assert_private()
+
   $options = $ssh::client::merged_options
   $use_augeas = $ssh::client::use_augeas
 
   if $use_augeas {
     create_resources('ssh_config', $options)
   } else {
-    file { $ssh::ssh_config:
+    file { $ssh::client::ssh_config:
       ensure  => file,
       owner   => '0',
       group   => '0',

--- a/manifests/client/config/user.pp
+++ b/manifests/client/config/user.pp
@@ -3,15 +3,44 @@
 # Contributor: Remi Ferrand <remi{dot}ferrand_at_cc(dot)in2p3.fr> (2015)
 # Contributor: Tim Meusel <tim@bastelfreak.de> (2017)
 #
+# @summary
+#   This defined type manages a users ssh config
+#
+# @param ensure
+#   Specifies whether the config file should be present or absent
+#
+# @param target
+#   Sets the config file location, defaults to `~/.ssh/config` if $target and $user_home_dir are not set
+#
+# @param user_home_dir
+#   Sets the location of users home dir, defaults to `/home/$user`
+#
+# @param manage_user_ssh_dir
+#   Whether the users ssh dir should be managed or not
+#
+# @param options
+#   Options which should be set
+#
+# @param user
+#   The name of the user the config should be managed for
+#
+# @param ssh_directory_default_mode
+#   Default mode for the users ssh dir
+#
+# @param ssh_config_default_mode
+#   Default mode for the ssh config file
+#
 define ssh::client::config::user (
-  Enum['present', 'absent']      $ensure              = present,
-  Optional[Stdlib::Absolutepath] $target              = undef,
-  Optional[Stdlib::Absolutepath] $user_home_dir       = undef,
-  Boolean                        $manage_user_ssh_dir = true,
-  Hash $options                                       = {},
-  String[1] $user                                     = $name,
+  Enum['present', 'absent']      $ensure                     = present,
+  Optional[Stdlib::Absolutepath] $target                     = undef,
+  Optional[Stdlib::Absolutepath] $user_home_dir              = undef,
+  Boolean                        $manage_user_ssh_dir        = true,
+  Hash                           $options                    = {},
+  String[1]                      $user                       = $name,
+  String[1]                      $ssh_directory_default_mode = '0700',
+  String[1]                      $ssh_config_default_mode    = '0600',
 ) {
-  include ssh
+  include ssh::client
 
   # If a specific target file was specified,
   # it must have higher priority than any
@@ -33,7 +62,7 @@ define ssh::client::config::user (
         file { $user_ssh_dir:
           ensure => directory,
           owner  => $user,
-          mode   => $ssh::user_ssh_directory_default_mode,
+          mode   => $ssh_directory_default_mode,
           before => Concat_file[$_target],
         }
       }
@@ -44,7 +73,7 @@ define ssh::client::config::user (
     concat_file { $_target:
       ensure => $ensure,
       owner  => $user,
-      mode   => $ssh::user_ssh_config_default_mode,
+      mode   => $ssh_config_default_mode,
       tag    => $name,
     }
   }

--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -1,7 +1,14 @@
+# @summary
+#   Install ssh client package
+#
+# @api private
+#
 class ssh::client::install {
-  if $ssh::client_package_name {
+  assert_private()
+
+  if $ssh::client::client_package_name {
     ensure_packages([
-        $ssh::client_package_name,
+        $ssh::client::client_package_name,
       ], {
         'ensure' => $ssh::client::ensure,
     })

--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -1,13 +1,31 @@
 # @summary
 #   This class manages hostkeys
 #
+# @param export_ipaddresses
+#   Whether ip addresses should be added as aliases
+#
+# @param storeconfigs_group
+#   Tag hostkeys with this group to allow segregation
+#
+# @param extra_aliases
+#   Additional aliases to set for host keys
+#
+# @param exclude_interfaces
+#   List of interfaces to exclude
+#
+# @param exclude_ipaddresses
+#   List of ip addresses to exclude
+#
+# @param use_trusted_facts
+#   Whether to use trusted or normal facts
+#
 class ssh::hostkeys (
-  Boolean          $export_ipaddresses  = true,
-  Optional[String] $storeconfigs_group  = undef,
-  Array            $extra_aliases       = [],
-  Array            $exclude_interfaces  = [],
-  Array            $exclude_ipaddresses = [],
-  Boolean          $use_trusted_facts   = false,
+  Boolean             $export_ipaddresses  = true,
+  Optional[String[1]] $storeconfigs_group  = undef,
+  Array               $extra_aliases       = [],
+  Array               $exclude_interfaces  = [],
+  Array               $exclude_ipaddresses = [],
+  Boolean             $use_trusted_facts   = false,
 ) {
   if $use_trusted_facts {
     $fqdn_real = $trusted['certname']

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -111,9 +111,6 @@
 #                AuthorizedKeysFile: '/dev/null'
 #
 #
-# @server_instances
-#   Configure SSH instances
-#
 # @param server_options
 #   Add dynamic options for ssh server config
 #
@@ -147,33 +144,26 @@
 # @param use_issue_net
 #   Use issue_net header
 #
+# @param purge_unmanaged_sshkeys
+#   Purge unmanaged sshkeys
+#
+# @param server_instances
+#   Configure SSH instances
+#
 class ssh (
-  Stdlib::Absolutepath $sshd_dir,
-  Stdlib::Absolutepath $sshd_binary,
-  Boolean $validate_sshd_file,
-  Stdlib::Absolutepath $sshd_config,
-  Stdlib::Absolutepath $ssh_config,
-  Stdlib::Filemode $user_ssh_directory_default_mode,
-  Stdlib::Filemode $user_ssh_config_default_mode,
-  Integer $host_priv_key_group,
-  String $service_name,
-  Boolean $collect_enabled,
-  Optional[Stdlib::Absolutepath] $sshd_environments_file     = undef,
-  Optional[String] $server_package_name                      = undef,
-  Optional[String] $client_package_name                      = undef,
-  Hash[String[1],Hash[String[1],NotUndef]] $server_instances = {},
-  Hash    $server_options                                    = {},
-  Hash    $server_match_block                                = {},
-  Hash    $client_options                                    = {},
-  Hash    $users_client_options                              = {},
-  String  $version                                           = 'present',
-  Boolean $storeconfigs_enabled                              = true,
-  Boolean $use_augeas                                        = false,
-  Array   $server_options_absent                             = [],
-  Array   $client_options_absent                             = [],
-  Boolean $use_issue_net                                     = false,
-  Boolean $purge_unmanaged_sshkeys                           = true,
-
+  Optional[Hash]                           $server_options          = undef,
+  Hash                                     $server_match_block      = {},
+  Optional[Hash]                           $client_options          = undef,
+  Hash                                     $users_client_options    = {},
+  String                                   $version                 = 'present',
+  Boolean                                  $storeconfigs_enabled    = true,
+  Boolean                                  $validate_sshd_file      = false,
+  Boolean                                  $use_augeas              = false,
+  Array                                    $server_options_absent   = [],
+  Array                                    $client_options_absent   = [],
+  Boolean                                  $use_issue_net           = false,
+  Boolean                                  $purge_unmanaged_sshkeys = true,
+  Hash[String[1],Hash[String[1],NotUndef]] $server_instances        = {},
 ) {
   class { 'ssh::server':
     ensure               => $version,

--- a/manifests/knownhosts.pp
+++ b/manifests/knownhosts.pp
@@ -8,8 +8,8 @@
 #   Define the hostkeys group storage
 #
 class ssh::knownhosts (
-  Boolean          $collect_enabled    = $ssh::collect_enabled,
-  Optional[String] $storeconfigs_group = undef,
+  Boolean             $collect_enabled    = $ssh::knownhosts::collect_enabled,
+  Optional[String[1]] $storeconfigs_group = undef,
 ) {
   if ($collect_enabled) {
     if $storeconfigs_group {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,4 +1,3 @@
-# @api private
 # @summary
 #   This class managed ssh server
 #
@@ -8,6 +7,24 @@
 #     storeconfigs_enabled => true,
 #     use_issue_net        => false,
 #   }
+#
+# @param service_name
+#   Name of the sshd service
+#
+# @param sshd_config
+#   Path to the sshd_config file
+#
+# @param sshd_dir
+#   Path to the sshd dir (e.g. /etc/ssh)
+#
+# @param sshd_binary
+#   Path to the sshd binary
+#
+# @param host_priv_key_group
+#   Name of the group for the private host key
+#
+# @param default_options
+#   Default options to set, will be merged with options parameter
 #
 # @param ensure
 #   Ensurable param to ssh server
@@ -30,25 +47,37 @@
 # @param match_block
 #   Add sshd match_block (with concat)
 #
-# @use_issue_net
+# @param use_issue_net
 #   Add issue_net banner
 #
+# @param sshd_environments_file
+#   Path to a sshd environments file (e.g. /etc/defaults/ssh on Debian)
+#
+# @param server_package_name
+#   Name of the server package to install
+#
 class ssh::server (
-  String  $ensure               = present,
-  Boolean $storeconfigs_enabled = true,
-  Hash    $options              = {},
-  Boolean $validate_sshd_file   = false,
-  Boolean $use_augeas           = false,
-  Array   $options_absent       = [],
-  Hash    $match_block          = {},
-  Boolean $use_issue_net        = false
+  String[1]                      $service_name,
+  Stdlib::Absolutepath           $sshd_config,
+  Stdlib::Absolutepath           $sshd_dir,
+  Stdlib::Absolutepath           $sshd_binary,
+  Integer                        $host_priv_key_group,
+  Hash                           $default_options,
+  Enum[present,absent]           $ensure                 = present,
+  Boolean                        $storeconfigs_enabled   = true,
+  Hash                           $options                = {},
+  Boolean                        $validate_sshd_file     = false,
+  Boolean                        $use_augeas             = false,
+  Array                          $options_absent         = [],
+  Hash                           $match_block            = {},
+  Boolean                        $use_issue_net          = false,
+  Optional[Stdlib::Absolutepath] $sshd_environments_file = undef,
+  Optional[String[1]]            $server_package_name    = undef,
 ) {
-  assert_private()
-
   if $use_augeas {
-    $merged_options = sshserver_options_to_augeas_sshd_config($options, $options_absent, { 'target' => $ssh::sshd_config })
+    $merged_options = sshserver_options_to_augeas_sshd_config($options, $options_absent, { 'target' => $ssh::server::sshd_config })
   } else {
-    $merged_options = $options
+    $merged_options = deep_merge($default_options, $options)
   }
 
   include ssh::server::install

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -4,6 +4,8 @@
 # @api private
 #
 class ssh::server::config {
+  assert_private()
+
   $options = $ssh::server::merged_options
 
   case $ssh::server::validate_sshd_file {
@@ -18,35 +20,35 @@ class ssh::server::config {
   if $ssh::server::use_augeas {
     create_resources('sshd_config', $options)
   } else {
-    concat { $ssh::sshd_config:
+    concat { $ssh::server::sshd_config:
       ensure       => present,
       owner        => 0,
       group        => 0,
       mode         => '0600',
       validate_cmd => $sshd_validate_cmd,
-      notify       => Service[$ssh::service_name],
+      notify       => Service[$ssh::server::service_name],
     }
 
     concat::fragment { 'global config':
-      target  => $ssh::sshd_config,
+      target  => $ssh::server::sshd_config,
       content => template("${module_name}/sshd_config.erb"),
       order   => '00',
     }
   }
 
   if $ssh::server::use_issue_net {
-    file { $ssh::issue_net:
+    file { $ssh::server::issue_net:
       ensure  => file,
       owner   => 0,
       group   => 0,
       mode    => '0644',
       content => template("${module_name}/issue.net.erb"),
-      notify  => Service[$ssh::service_name],
+      notify  => Service[$ssh::server::service_name],
     }
 
     concat::fragment { 'banner file':
-      target  => $ssh::sshd_config,
-      content => "Banner ${ssh::issue_net}\n",
+      target  => $ssh::server::sshd_config,
+      content => "Banner ${ssh::server::issue_net}\n",
       order   => '01',
     }
   }

--- a/manifests/server/config/setting.pp
+++ b/manifests/server/config/setting.pp
@@ -1,14 +1,21 @@
 # @summary
 #   Internal define to managed ssh server param
 #
-# @api private
+# @param key
+#   Key of the value which should be set
+#
+# @param value
+#   Value which should be set
+#
+# @param order
+#   Orders your setting within the config file
 #
 define ssh::server::config::setting (
-  $key,
-  $value,
-  $order = '10'
+  String[1]                             $key,
+  Variant[Boolean, Array, Hash, String] $value,
+  Variant[String[1], Integer]           $order = '10'
 ) {
-  include ssh
+  include ssh::server
 
   if is_bool($value) {
     $real_value = $value ? {
@@ -25,7 +32,7 @@ define ssh::server::config::setting (
   }
 
   concat::fragment { "ssh_setting_${name}_${key}":
-    target  => $ssh::sshd_config,
+    target  => $ssh::server::sshd_config,
     content => "\n# added by Ssh::Server::Config::Setting[${name}]\n${key} ${real_value}\n",
     order   => $order,
   }

--- a/manifests/server/host_key.pp
+++ b/manifests/server/host_key.pp
@@ -1,84 +1,86 @@
-# == Define: ssh::server::host_key
+# @summary
+#   Manage a ssh host key
 #
-# This module install a ssh host key in the server (basically, it is
-# a file resource but it also notifies to the ssh service)
+#   This module install a ssh host key in the server (basically, it is
+#   a file resource but it also notifies to the ssh service)
 #
-# Important! This define does not modify any option in sshd_config, so
-# you have to manually define the HostKey option in the server options
-# if you haven't done yet.
+#   Important! This define does not modify any option in sshd_config, so
+#   you have to manually define the HostKey option in the server options
+#   if you haven't done yet.
 #
-# == Parameters
-#
-# [*ensure*]
+# @param ensure
 #   Set to 'absent' to remove host_key files
 #
-# [*public_key_source*]
+# @param public_key_source
 #   Sets the content of the source parameter for the public key file
 #   Note public_key_source and public_key_content are mutually exclusive.
 #
-# [*public_key_content*]
+# @param public_key_content
 #   Sets the content for the public key file.
 #   Note public_key_source and public_key_content are mutually exclusive.
 #
-# [*private_key_source*]
+# @param private_key_source
 #   Sets the content of the source parameter for the private key file
 #   Note private_key_source and private_key_content are mutually exclusive.
 #
-# [*private_key_content*]
+# @param private_key_content
 #   Sets the content for the private key file.
 #   Note private_key_source and private_key_content are mutually exclusive.
 #
-# [*certificate_source*]
+# @param certificate_source
 #   Sets the content of the source parameter for the host key certificate.
 #   Note certificate_source and certificate_content are mutually exclusive.
 #
-# [*certificate_content*]
+# @param certificate_content
 #   Sets the content for the host key certificate.
 #   Note certificate_source and certificate_content are mutually exclusive.
 #
 define ssh::server::host_key (
-  $ensure              = 'present',
-  $public_key_source   = '',
-  $public_key_content  = '',
-  $private_key_source  = '',
-  $private_key_content = '',
-  $certificate_source  = '',
-  $certificate_content = '',
+  Enum[present, absent] $ensure              = 'present',
+  Optional[String[1]]   $public_key_source   = undef,
+  Optional[String[1]]   $public_key_content  = undef,
+  Optional[String[1]]   $private_key_source  = undef,
+  Optional[String[1]]   $private_key_content = undef,
+  Optional[String[1]]   $certificate_source  = undef,
+  Optional[String[1]]   $certificate_content = undef,
 ) {
   # Ensure the ssh::server class is included in the manifest
   include ssh::server
 
-  if $public_key_source == '' and $public_key_content == '' and $ensure == 'present' {
-    fail('You must provide either public_key_source or public_key_content parameter')
-  }
-  if $private_key_source == '' and $private_key_content == '' and $ensure == 'present' {
-    fail('You must provide either private_key_source or private_key_content parameter')
+  if $ensure == 'present' {
+    if ! $public_key_source and ! $public_key_content {
+      fail('You must provide either public_key_source or public_key_content parameter')
+    }
+
+    if ! $private_key_source and ! $private_key_content {
+      fail('You must provide either private_key_source or private_key_content parameter')
+    }
   }
 
   $manage_pub_key_content = $public_key_source ? {
-    ''      => $public_key_content,
+    undef   => $public_key_content,
     default => undef,
   }
   $manage_pub_key_source = $public_key_source ? {
-    ''      => undef,
+    undef   => undef,
     default => $public_key_source,
   }
 
   $manage_priv_key_content = $private_key_source ? {
-    ''      => $private_key_content,
+    undef   => $private_key_content,
     default => undef,
   }
   $manage_priv_key_source = $private_key_source ? {
-    ''      => undef,
+    undef   => undef,
     default => $private_key_source,
   }
 
   $manage_cert_content = $certificate_source ? {
-    ''      => $certificate_content,
+    undef   => $certificate_content,
     default => undef,
   }
   $manage_cert_source = $certificate_source ? {
-    ''      => undef,
+    undef   => undef,
     default => $certificate_source,
   }
 
@@ -88,7 +90,7 @@ define ssh::server::host_key (
       owner   => 0,
       group   => 0,
       mode    => '0644',
-      path    => "${ssh::sshd_dir}/${name}.pub",
+      path    => "${ssh::server::sshd_dir}/${name}.pub",
       source  => $manage_pub_key_source,
       content => $manage_pub_key_content,
       notify  => Class['ssh::server::service'],
@@ -97,9 +99,9 @@ define ssh::server::host_key (
     file { "${name}_priv":
       ensure    => $ensure,
       owner     => 0,
-      group     => $ssh::host_priv_key_group,
+      group     => $ssh::server::host_priv_key_group,
       mode      => '0600',
-      path      => "${ssh::sshd_dir}/${name}",
+      path      => "${ssh::server::sshd_dir}/${name}",
       source    => $manage_priv_key_source,
       content   => $manage_priv_key_content,
       show_diff => false,
@@ -111,16 +113,16 @@ define ssh::server::host_key (
       owner  => 0,
       group  => 0,
       mode   => '0644',
-      path   => "${ssh::sshd_dir}/${name}.pub",
+      path   => "${ssh::server::sshd_dir}/${name}.pub",
       notify => Class['ssh::server::service'],
     }
 
     file { "${name}_priv":
       ensure    => $ensure,
       owner     => 0,
-      group     => $ssh::host_priv_key_group,
+      group     => $ssh::server::host_priv_key_group,
       mode      => '0600',
-      path      => "${ssh::sshd_dir}/${name}",
+      path      => "${ssh::server::sshd_dir}/${name}",
       show_diff => false,
       notify    => Class['ssh::server::service'],
     }
@@ -133,7 +135,7 @@ define ssh::server::host_key (
         owner   => 0,
         group   => 0,
         mode    => '0644',
-        path    => "${ssh::sshd_dir}/${name}-cert.pub",
+        path    => "${ssh::server::sshd_dir}/${name}-cert.pub",
         source  => $manage_cert_source,
         content => $manage_cert_content,
         notify  => Class['ssh::server::service'],
@@ -144,7 +146,7 @@ define ssh::server::host_key (
         owner  => 0,
         group  => 0,
         mode   => '0644',
-        path   => "${ssh::sshd_dir}/${name}-cert.pub",
+        path   => "${ssh::server::sshd_dir}/${name}-cert.pub",
         notify => Class['ssh::server::service'],
       }
     }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -4,10 +4,11 @@
 # @api private
 #
 class ssh::server::install {
-  include ssh
-  if $ssh::server_package_name {
+  assert_private()
+
+  if $ssh::server::server_package_name {
     ensure_packages ([
-        $ssh::server_package_name,
+        $ssh::server::server_package_name,
       ], {
         'ensure' => $ssh::server::ensure,
     })

--- a/manifests/server/instances.pp
+++ b/manifests/server/instances.pp
@@ -1,22 +1,41 @@
-# @summary A short summary of the purpose of this defined type.
+# @summary 
+#   Configure separate ssh server instances
 #
-# A description of what this defined type does
+# @param ensure
+#   Specifies whether the instance should be added or removed
 #
-# @options
-#   Structure see main class
+# @param options
+#   Set options for the instance
 #
-#   ssh::instances { 'namevar': }
+# @param service_ensure
+#   Whether this instance service should be running or stopped
+#
+# @param service_enable
+#   Whether this instance service should be started at boot
+#
+# @param validate_config_file
+#   Validate config file before applying
+#
+# @param sshd_instance_config_file
+#   Path of the instance sshd config
+#
+# @param sshd_binary
+#   Path to sshd binary
+#
+# @param sshd_environments_file
+#   Path to environments file, if any
+#
 define ssh::server::instances (
-  Enum[present, absent]  $ensure                         = present,
-  Hash    $options                                       = {},
-  Stdlib::Ensure::Service  $service_ensure               = 'running',
-  Boolean $service_enable                                = true,
-  Boolean $validate_config_file                          = false,
-  Stdlib::Absolutepath $sshd_instance_config_file        = "${ssh::sshd_dir}/sshd_config.${title}",
-  Stdlib::Absolutepath $sshd_binary                      = $ssh::sshd_binary,
-  Optional[Stdlib::Absolutepath] $sshd_environments_file = $ssh::sshd_environments_file,
+  Enum[present, absent]          $ensure                    = present,
+  Hash                           $options                   = {},
+  Stdlib::Ensure::Service        $service_ensure            = 'running',
+  Boolean                        $service_enable            = true,
+  Boolean                        $validate_config_file      = false,
+  Stdlib::Absolutepath           $sshd_instance_config_file = "${ssh::server::sshd_dir}/sshd_config.${title}",
+  Stdlib::Absolutepath           $sshd_binary               = $ssh::server::sshd_binary,
+  Optional[Stdlib::Absolutepath] $sshd_environments_file    = $ssh::server::sshd_environments_file,
 ) {
-  include ssh
+  include ssh::server
 
   $sshd_instance_config       = assert_type(Hash, pick($options['sshd_config'], {}))
   $sshd_instance_matchblocks  = assert_type(Hash, pick($options['match_blocks'], {}))

--- a/manifests/server/match_block.pp
+++ b/manifests/server/match_block.pp
@@ -1,11 +1,23 @@
 # @summary
-#   Add match_block to ssh server config (concat needed)
+#   Add match_block to ssh server config
+#
+# @param options
+#   Options which should be set
+#
+# @param type
+#   Type of match_block, e.g. user, group, host, ...
+#
+# @param order
+#   Orders your settings within the config file
+#
+# @param target
+#   Sets the target file of the concat fragment
 #
 define ssh::server::match_block (
-  Hash $options  = {},
-  String $type   = 'user',
-  Integer $order = 50,
-  Stdlib::Absolutepath $target = $ssh::params::sshd_config,
+  Hash                 $options = {},
+  String[1]            $type    = 'user',
+  Integer              $order   = 50,
+  Stdlib::Absolutepath $target  = $ssh::server::sshd_config,
 ) {
   if $ssh::server::use_augeas {
     fail('ssh::server::match_block() define not supported with use_augeas = true')

--- a/manifests/server/options.pp
+++ b/manifests/server/options.pp
@@ -1,14 +1,18 @@
 # @summary
-#   Managed ssh server options
+#   This defined type manages ssh server options
 #
-# @api private
+# @param options
+#   Options which should be set
+#
+# @param order
+#   Orders your settings within the config file
 #
 define ssh::server::options (
-  Hash $options  = {},
-  Integer $order = 50
+  Hash    $options = {},
+  Integer $order   = 50
 ) {
   concat::fragment { "options ${name}":
-    target  => $ssh::sshd_config,
+    target  => $ssh::server::sshd_config,
     content => template("${module_name}/options.erb"),
     order   => 100+$order,
   }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,6 +1,8 @@
 # @summary
 #   This class managed ssh server service
 #
+# @api private
+#
 # @param ensure
 #   Ensurable service param
 #
@@ -8,13 +10,12 @@
 #   Define if service is enable
 #
 class ssh::server::service (
-  String  $ensure = 'running',
-  Boolean $enable = true
+  Stdlib::Ensure::Service $ensure = 'running',
+  Boolean                 $enable = true,
 ) {
-  include ssh
-  include ssh::server
+  assert_private()
 
-  service { $ssh::service_name:
+  service { $ssh::server::service_name:
     ensure     => $ssh::server::service::ensure,
     hasstatus  => true,
     hasrestart => true,

--- a/spec/acceptance/init_spec.rb
+++ b/spec/acceptance/init_spec.rb
@@ -18,15 +18,18 @@ describe 'ssh' do
       describe package(package_name) do
         it { is_expected.to be_installed }
       end
+
       describe port(22) do
         it { is_expected.to be_listening }
       end
+
       describe service('sshd') do
         it { is_expected.to be_enabled }
         it { is_expected.to be_running }
       end
     end
   end
+
   context 'Server with a seperate sftp_server_init instance on Port 8022' do
     it_behaves_like 'an idempotent resource' do
       let(:manifest) do
@@ -57,9 +60,11 @@ describe 'ssh' do
       describe package(package_name) do
         it { is_expected.to be_installed }
       end
+
       describe port(8022) do
         it { is_expected.to be_listening }
       end
+
       describe service('sftp_server_init') do
         it { is_expected.to be_enabled }
         it { is_expected.to be_running }

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ssh::client', type: 'class' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      context 'with no other parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('ssh::knownhosts') }
+        it { is_expected.to contain_class('ssh::client::config') }
+        it { is_expected.to contain_class('ssh::client::install') }
+        it { is_expected.to contain_file('/etc/ssh/ssh_config') }
+      end
+
+      context 'with a different ssh_config location' do
+        let :params do
+          {
+            ssh_config: '/etc/ssh/another_ssh_config'
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/ssh/another_ssh_config') }
+      end
+
+      context 'with storeconfigs_enabled set to false' do
+        let :params do
+          {
+            storeconfigs_enabled: false
+          }
+        end
+
+        it { is_expected.not_to contain_class('ssh::knownhosts') }
+      end
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,48 +1,116 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'ssh', type: 'class' do
   on_supported_os.each do |os, os_facts|
-    let(:facts) { os_facts }
-
     context "on #{os}" do
-      context 'Server with a seperate sftp_server_init instance on Port 8022' do
-        let :params do
-          {
-            'server_instances' => {
-              'sftp_server_init' => {
-                'ensure' => 'present',
-                'options' => {
-                  'sshd_config' => {
-                    'Port' => 8022,
-                    'Protocol' => 2,
-                    'AddressFamily' => 'any',
-                    'HostKey' => '/etc/ssh/ssh_host_rsa_key',
-                    'SyslogFacility' => 'AUTH',
-                    'LogLevel' => 'INFO',
-                    'PermitRootLogin' => 'no',
+      let(:facts) { os_facts }
+
+      case os_facts[:os]['family']
+      when 'Debian'
+        client_package = 'openssh-client'
+        server_package = 'openssh-server'
+        sftp_server_path = '/usr/lib/openssh/sftp-server'
+      when 'Archlinux'
+        client_package = 'openssh'
+        server_package = 'openssh'
+        sftp_server_path = '/usr/lib/ssh/sftp-server'
+      when 'Amazon', 'RedHat'
+        client_package = 'openssh-clients'
+        server_package = 'openssh-server'
+        sftp_server_path = '/usr/libexec/openssh/sftp-server'
+      when 'Gentoo'
+        client_package = 'openssh'
+        server_package = 'openssh'
+        sftp_server_path = '/usr/lib64/misc/sftp-server'
+      when 'Solaris'
+        case os_facts[:os]['release']['major']
+        when 10
+          client_package = 'SUNWsshu'
+          server_package = 'SUNWsshdu'
+        else
+          client_package = '/network/ssh'
+          server_package = '/service/network/ssh'
+        end
+        sftp_server_path = 'internal-sftp'
+      when 'SmartOS'
+        sftp_server_path = 'internal-sftp'
+      when 'Suse'
+        client_package = 'openssh'
+        server_package = 'openssh'
+        case os_facts[:os]['name']
+        when 'OpenSuSE'
+          sftp_server_path = '/usr/lib/ssh/sftp-server'
+        when 'SLES'
+          sftp_server_path = case os_facts[:os]['release']['major']
+                             when 10, 11
+                               '/usr/lib64/ssh/sftp-server'
+                             else
+                               '/usr/lib/ssh/sftp-server'
+                             end
+        end
+      else
+        client_package = nil
+        server_package = nil
+        sftp_server_path = '/usr/libexec/sftp-server'
+      end
+
+      case os_facts[:os]['family']
+      when 'Solaris'
+        ssh_config_expected_default = "# File managed by Puppet\n\n"
+        ssh_config_expected_custom = "# File managed by Puppet\n\nHostFoo\n    HostName bar\nSomeOtherKey someValue\n"
+        sshd_config_default = "# File is managed by Puppet\n\nChallengeResponseAuthentication no\nHostKey /etc/ssh/ssh_host_rsa_key\nHostKey /etc/ssh/ssh_host_dsa_key\nPrintMotd no\nSubsystem sftp #{sftp_server_path}\nX11Forwarding yes\n"
+        sshd_config_custom = "# File is managed by Puppet\n\nChallengeResponseAuthentication no\nHostKey /etc/ssh/ssh_host_rsa_key\nHostKey /etc/ssh/ssh_host_dsa_key\nPrintMotd no\nSomeOtherKey someValue\nSubsystem sftp #{sftp_server_path}\nUsePAM no\nX11Forwarding no\n"
+      else
+        ssh_config_expected_default = "# File managed by Puppet\n\nHost *\n    HashKnownHosts yes\n    SendEnv LANG LC_*\n"
+        ssh_config_expected_custom = "# File managed by Puppet\n\nHostFoo\n    HostName bar\nSomeOtherKey someValue\nHost *\n    HashKnownHosts yes\n    SendEnv LANG LC_*\n"
+        sshd_config_default = "# File is managed by Puppet\n\nAcceptEnv LANG LC_*\nChallengeResponseAuthentication no\nPrintMotd no\nSubsystem sftp #{sftp_server_path}\nUsePAM yes\nX11Forwarding yes\n"
+        sshd_config_custom = "# File is managed by Puppet\n\nAcceptEnv LANG LC_*\nChallengeResponseAuthentication no\nPrintMotd no\nSomeOtherKey someValue\nSubsystem sftp #{sftp_server_path}\nUsePAM no\nX11Forwarding no\n"
+      end
+
+      if os_facts[:kernel] == 'Linux'
+        context 'Server with a separate sftp_server_init instance on Port 8022' do
+          let :params do
+            {
+              'server_instances' => {
+                'sftp_server_init' => {
+                  'ensure' => 'present',
+                  'options' => {
+                    'sshd_config' => {
+                      'Port' => 8022,
+                      'Protocol' => 2,
+                      'AddressFamily' => 'any',
+                      'HostKey' => '/etc/ssh/ssh_host_rsa_key',
+                      'SyslogFacility' => 'AUTH',
+                      'LogLevel' => 'INFO',
+                      'PermitRootLogin' => 'no',
+                    },
+                    'sshd_service_options' => '',
+                    'match_blocks' => {},
                   },
-                  'sshd_service_options' => '',
-                  'match_blocks' => {},
                 },
               },
-            },
-          }
-        end
+            }
+          end
 
-        it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat('/etc/ssh/sshd_config.sftp_server_init') }
-        it { is_expected.to contain_concat__fragment('sshd instance sftp_server_init config') }
-        it { is_expected.to contain_systemd__unit_file('sftp_server_init.service') }
-        it { is_expected.to contain_service('sftp_server_init.service') }
-        it { is_expected.to contain_ssh__server__instances('sftp_server_init') }
-        it { is_expected.to contain_class('ssh::client') }
-        it { is_expected.to contain_class('ssh::server') }
-        it { is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd(nil) }
-        it { is_expected.to contain_resources('sshkey').with_purge(true) }
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_concat('/etc/ssh/sshd_config.sftp_server_init') }
+          it { is_expected.to contain_concat__fragment('sshd instance sftp_server_init config').with_content("# File is managed by Puppet\nAddressFamily any\nPort 8022\n\nHostKey /etc/ssh/ssh_host_rsa_key\nLogLevel INFO\nPermitRootLogin no\nProtocol 2\nSyslogFacility AUTH\n") }
+          it { is_expected.to contain_systemd__unit_file('sftp_server_init.service') }
+          it { is_expected.to contain_service('sftp_server_init.service') }
+          it { is_expected.to contain_ssh__server__instances('sftp_server_init') }
+          it { is_expected.to contain_class('ssh::client') }
+          it { is_expected.to contain_class('ssh::server') }
+          it { is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd(nil) }
+          it { is_expected.to contain_resources('sshkey').with_purge(true) }
+        end
       end
+
       context 'with all defaults' do
         it { is_expected.to compile.with_all_deps }
       end
+
       context 'with the validate_sshd_file setting' do
         let :params do
           {
@@ -50,9 +118,9 @@ describe 'ssh', type: 'class' do
           }
         end
 
-        it { is_expected.to contain_class('ssh::client') }
         it { is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd('/usr/sbin/sshd -tf %') }
       end
+
       context 'without resource purging' do
         let :params do
           {
@@ -62,11 +130,56 @@ describe 'ssh', type: 'class' do
 
         it { is_expected.not_to contain_resources('sshkey') }
       end
+
       context 'with no other parameters' do
         it { is_expected.to contain_class('ssh::client') }
         it { is_expected.to contain_class('ssh::server') }
+        it { is_expected.to contain_file('/etc/ssh/ssh_config').with_content(ssh_config_expected_default) }
         it { is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd(nil) }
         it { is_expected.to contain_resources('sshkey').with_purge(true) }
+        it { is_expected.to contain_concat__fragment('global config').with_content(sshd_config_default) }
+
+        it { is_expected.to contain_package(client_package).with_ensure('installed') } if client_package
+        it { is_expected.to contain_package(server_package).with_ensure('installed') } if server_package
+      end
+
+      context 'with custom server options' do
+        let :params do
+          {
+            server_options: {
+              X11Forwarding: 'no',
+              UsePAM: 'no',
+              SomeOtherKey: 'someValue'
+            }
+          }
+        end
+
+        it { is_expected.to contain_concat__fragment('global config').with_content(sshd_config_custom) }
+      end
+
+      context 'with custom client options' do
+        let :params do
+          {
+            client_options: {
+              HostFoo: {
+                HostName: 'bar'
+              },
+              SomeOtherKey: 'someValue'
+            }
+          }
+        end
+
+        it { is_expected.to contain_file('/etc/ssh/ssh_config').with_content(ssh_config_expected_custom) }
+      end
+
+      context 'with storeconfigs_enabled set to false' do
+        let :params do
+          {
+            storeconfigs_enabled: false
+          }
+        end
+
+        it { is_expected.not_to contain_class('ssh::knownhosts') }
       end
     end
   end

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ssh::server', type: 'class' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      svc_name = case os_facts[:os]['family']
+                 when 'Debian'
+                   'ssh'
+                 when 'Archlinux'
+                   'sshd.service'
+                 when 'Darwin'
+                   'com.openssh.sshd'
+                 when 'Solaris', 'SmartOS'
+                   'svc:/network/ssh:default'
+                 else
+                   'sshd'
+                 end
+
+      sshd_config_custom = case os_facts[:os]['family']
+                           when 'Solaris'
+                             "# File is managed by Puppet\n\nChallengeResponseAuthentication no\nHostKey /etc/ssh/ssh_host_rsa_key\nHostKey /etc/ssh/ssh_host_dsa_key\nPrintMotd no\nSomeOtherKey someValue\nSubsystem sftp /some/path\nUsePAM no\nX11Forwarding no\n"
+                           else
+                             "# File is managed by Puppet\n\nAcceptEnv LANG LC_*\nChallengeResponseAuthentication no\nPrintMotd no\nSomeOtherKey someValue\nSubsystem sftp /some/path\nUsePAM no\nX11Forwarding no\n"
+                           end
+
+      context 'with no other parameters' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('ssh::knownhosts') }
+        it { is_expected.to contain_class('ssh::server::config') }
+        it { is_expected.to contain_class('ssh::server::install') }
+        it { is_expected.to contain_class('ssh::server::service') }
+        it { is_expected.to contain_service(svc_name) }
+        it { is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd(nil) }
+        it { is_expected.to contain_concat__fragment('global config') }
+      end
+
+      context 'with custom options' do
+        let :params do
+          {
+            options: {
+              Subsystem: 'sftp /some/path',
+              X11Forwarding: 'no',
+              UsePAM: 'no',
+              SomeOtherKey: 'someValue'
+            }
+          }
+        end
+
+        it { is_expected.to contain_concat__fragment('global config').with_content(sshd_config_custom) }
+      end
+
+      context 'with a custom service_name' do
+        let :params do
+          {
+            service_name: 'custom_sshd_name'
+          }
+        end
+
+        it { is_expected.to contain_service('custom_sshd_name') }
+      end
+
+      context 'with the validate_sshd_file setting' do
+        let :params do
+          {
+            validate_sshd_file: true
+          }
+        end
+
+        it { is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd('/usr/sbin/sshd -tf %') }
+      end
+
+      context 'with a different sshd_config location' do
+        let :params do
+          {
+            sshd_config: '/etc/ssh/another_sshd_config'
+          }
+        end
+
+        it { is_expected.to contain_concat('/etc/ssh/another_sshd_config') }
+      end
+
+      context 'with storeconfigs_enabled set to false' do
+        let :params do
+          {
+            storeconfigs_enabled: false
+          }
+        end
+
+        it { is_expected.not_to contain_class('ssh::knownhosts') }
+      end
+    end
+  end
+end

--- a/spec/defines/client/config/user_spec.rb
+++ b/spec/defines/client/config/user_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'ssh::client::config::user' do

--- a/spec/defines/server/config/setting_spec.rb
+++ b/spec/defines/server/config/setting_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'ssh::server::config::setting' do
@@ -10,6 +12,7 @@ describe 'ssh::server::config::setting' do
       context 'with all defaults' do
         it { is_expected.not_to compile }
       end
+
       describe 'with key => "AllowGroups", value => "group1 group2"' do
         let :params do
           {

--- a/spec/defines/server/host_key_spec.rb
+++ b/spec/defines/server/host_key_spec.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'ssh::server::host_key', type: :define do
   on_supported_os.each do |os, os_facts|
-    let(:facts) { os_facts }
-
     context "on #{os}" do
+      let(:facts) { os_facts }
       let(:title) { 'something' }
       let(:pre_condition) { 'include ssh' }
 
       context 'with all defaults' do
         it { is_expected.to compile.and_raise_error(%r{You must provide either public_key_source or public_key_content parameter}) }
       end
+
       describe 'with public_key_content, private_key_content and certificate_content' do
         let :params do
           {
@@ -21,6 +23,7 @@ describe 'ssh::server::host_key', type: :define do
         end
 
         it { is_expected.to compile.with_all_deps }
+
         it {
           is_expected.to contain_file('something_pub').
             with_content('abc').

--- a/spec/defines/server/instances_spec.rb
+++ b/spec/defines/server/instances_spec.rb
@@ -77,9 +77,7 @@ describe 'ssh::server::instances' do
       context "on #{os}" do
         let(:facts) { os_facts }
 
-        if os_facts[:kernel] != 'Linux'
-          it { is_expected.to compile.and_raise_error(%r{not supported, because Systemd is not available}) }
-        else
+        if os_facts[:kernel] == 'Linux'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_concat('/etc/ssh/sshd_config.sftp_server') }
           it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
@@ -87,10 +85,13 @@ describe 'ssh::server::instances' do
           it { is_expected.to contain_ssh__server__match_block('*,!ssh_exempt_ldap_authkey,!sshlokey') }
           it { is_expected.to contain_systemd__unit_file('sftp_server.service') }
           it { is_expected.to contain_service('sftp_server.service') }
+        else
+          it { is_expected.to compile.and_raise_error(%r{not supported, because Systemd is not available}) }
         end
       end
     end
   end
+
   context 'minimal setup' do
     let(:title) { 'sftp_server' }
     let :pre_condition do
@@ -119,13 +120,13 @@ describe 'ssh::server::instances' do
       context "on #{os}" do
         let(:facts) { os_facts }
 
-        if os_facts[:kernel] != 'Linux'
-          it { is_expected.to compile.and_raise_error(%r{not supported, because Systemd is not available}) }
-        else
+        if os_facts[:kernel] == 'Linux'
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
           it { is_expected.to contain_systemd__unit_file('sftp_server.service') }
           it { is_expected.to contain_service('sftp_server.service') }
+        else
+          it { is_expected.to compile.and_raise_error(%r{not supported, because Systemd is not available}) }
         end
       end
     end

--- a/spec/defines/server/match_block_spec.rb
+++ b/spec/defines/server/match_block_spec.rb
@@ -27,6 +27,7 @@ describe 'ssh::server::match_block' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_concat__fragment('match_block *,!ssh_exempt_ldap_authkey,!sshlokey') }
       end
+
       context 'with ssh_deny_pw_auth,sshdnypw' do
         let(:title) { 'ssh_deny_pw_auth,sshdnypw' }
         let(:params) do

--- a/spec/functions/ssh/ipaddresses_spec.rb
+++ b/spec/functions/ssh/ipaddresses_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'ssh::ipaddresses', type: :puppet_function do
@@ -21,6 +23,7 @@ describe 'ssh::ipaddresses', type: :puppet_function do
         is_expected.to run.with_params(['docker0']).and_return(['10.13.42.61', '10.0.0.110', '10.0.0.104', '10.0.0.109'])
       end
     end
+
     describe 'with excluded interfaces' do
       it 'doesn\'t return the IPs of those interfaces' do
         is_expected.to run.with_params(%w[docker0 eno1]).and_return([])
@@ -50,6 +53,7 @@ describe 'ssh::ipaddresses', type: :puppet_function do
         is_expected.to run.with_params(['docker0']).and_return(['10.13.42.61'])
       end
     end
+
     describe 'with excluded interfaces' do
       it 'doesn\'t return the IPs of those interfaces' do
         is_expected.to run.with_params(%w[docker0 eno1]).and_return([])

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,17 @@
+# frozen_string_literal: true
+
 # Managed by modulesync - DO NOT EDIT
 # https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
 
 # puppetlabs_spec_helper will set up coverage if the env variable is set.
 # We want to do this if lib exists and it hasn't been explicitly set.
-ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../../lib', __FILE__))
+ENV['COVERAGE'] ||= 'yes' if Dir.exist?(File.expand_path('../lib', __dir__))
 
 require 'voxpupuli/test/spec_helper'
 
 if File.exist?(File.join(__dir__, 'default_module_facts.yml'))
   facts = YAML.safe_load(File.read(File.join(__dir__, 'default_module_facts.yml')))
-  if facts
-    facts.each do |name, value|
-      add_custom_fact name.to_sym, value
-    end
+  facts&.each do |name, value|
+    add_custom_fact name.to_sym, value
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'voxpupuli/acceptance/spec_helper_acceptance'
 
 configure_beaker

--- a/spec/unit/facter/util/fact_ssh_client_version_spec.rb
+++ b/spec/unit/facter/util/fact_ssh_client_version_spec.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'ssh_client_version_full' do
   before { Facter.clear }
+
   after { Facter.clear }
 
   context 'when on a Linux host' do
@@ -10,16 +13,19 @@ describe 'ssh_client_version_full' do
       allow(Facter::Util::Resolution).to receive(:which).with('ssh').and_return('/usr/bin/ssh')
       allow(Facter::Util::Resolution).to receive(:exec).with('ssh -V 2>&1').and_return('OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.8, OpenSSL 1.0.1f 6 Jan 2014')
     end
+
     it 'execs ssh -V and returns full version number' do
       expect(Facter.fact(:ssh_client_version_full).value).to eq('6.6.1p1')
     end
   end
+
   context 'when on a SunOS host' do
     before do
       allow(Facter.fact(:kernel)).to receive(:value).and_return('SunOS')
       allow(Facter::Util::Resolution).to receive(:which).with('ssh').and_return('/usr/bin/ssh')
       allow(Facter::Util::Resolution).to receive(:exec).with('ssh -V 2>&1').and_return('Sun_SSH_2.4, SSH protocols 1.5/2.0, OpenSSL 0x100020bf')
     end
+
     it 'execs ssh -V and returns full version number' do
       expect(Facter.fact(:ssh_client_version_full).value).to eq('2.4')
     end

--- a/spec/unit/facter/util/fact_ssh_server_version_major_spec.rb
+++ b/spec/unit/facter/util/fact_ssh_server_version_major_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Facter::Util::Fact do
@@ -12,6 +14,7 @@ describe Facter::Util::Fact do
         before do
           allow(Facter.fact(:ssh_server_version_full)).to receive(:value).and_return('6.6.1p1')
         end
+
         it do
           expect(Facter.fact(:ssh_server_version_major).value).to eq('6')
         end
@@ -23,6 +26,7 @@ describe Facter::Util::Fact do
         before do
           allow(Facter.fact(:ssh_server_version_full)).to receive(:value).and_return('7.2p2')
         end
+
         it do
           expect(Facter.fact(:ssh_server_version_major).value).to eq('7')
         end
@@ -33,6 +37,7 @@ describe Facter::Util::Fact do
       before do
         allow(Facter.fact(:ssh_server_version_full)).to receive(:value).and_return(nil)
       end
+
       it do
         expect(Facter.fact(:ssh_server_version_major).value).to be_nil
       end

--- a/spec/unit/facter/util/fact_ssh_server_version_spec.rb
+++ b/spec/unit/facter/util/fact_ssh_server_version_spec.rb
@@ -1,7 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'ssh_server_version_full' do
   before { Facter.clear }
+
   after { Facter.clear }
 
   context 'when on a Linux host' do
@@ -10,16 +13,19 @@ describe 'ssh_server_version_full' do
       allow(Facter::Util::Resolution).to receive(:which).with('sshd').and_return('/usr/bin/sshd')
       allow(Facter::Util::Resolution).to receive(:exec).with('sshd -V 2>&1').and_return('OpenSSH_6.6.1p1 Ubuntu-2ubuntu2.8, OpenSSL 1.0.1f 6 Jan 2014')
     end
+
     it 'execs sshd -V and returns full version number' do
       expect(Facter.fact(:ssh_server_version_full).value).to eq('6.6.1p1')
     end
   end
+
   context 'when on a SunOS host' do
     before do
       allow(Facter.fact(:kernel)).to receive(:value).and_return('SunOS')
       allow(Facter::Util::Resolution).to receive(:which).with('sshd').and_return('/usr/bin/sshd')
       allow(Facter::Util::Resolution).to receive(:exec).with('sshd -V 2>&1').and_return('Sun_SSH_2.4, SSH protocols 1.5/2.0, OpenSSL 0x100020bf')
     end
+
     it 'execs sshd -V and returns full version number' do
       expect(Facter.fact(:ssh_server_version_full).value).to eq('2.4')
     end

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -11,11 +11,10 @@
     end
   end
 -%>
-<%- options = scope.lookupvar('ssh::server::merged_options') -%>
-<%- if addressfamily = options.delete('AddressFamily') -%>
+<%- if addressfamily = @options.delete('AddressFamily') -%>
 AddressFamily <%= addressfamily %>
 <%- end -%>
-<%- if port = options.delete('Port') -%>
+<%- if port = @options.delete('Port') -%>
 <%- if port.is_a?(Array) -%>
 <%- port.reject{ |x| x.to_s.strip.empty? }.each do |p| -%>
 Port <%= p %>
@@ -24,7 +23,7 @@ Port <%= p %>
 Port <%= port %>
 <%- end -%>
 <%- end -%>
-<%- if listen = options.delete('ListenAddress') -%>
+<%- if listen = @options.delete('ListenAddress') -%>
 <%- if listen.is_a?(Array) -%>
 <%- listen.reject{ |x| x.strip.empty? }.each do |l| -%>
 ListenAddress <%= l %>
@@ -34,8 +33,8 @@ ListenAddress <%= listen %>
 <%- end -%>
 <%- end -%>
 
-<%- options.keys.sort_by{ |sk| (sk.to_s.downcase.include? "match") ? 'zzz' + sk.to_s : sk.to_s }.each do |k| -%>
-<%- v = options[k] -%>
+<%- @options.keys.sort_by{ |sk| (sk.to_s.downcase.include? "match") ? 'zzz' + sk.to_s : sk.to_s }.each do |k| -%>
+<%- v = @options[k] -%>
 <%- if v.is_a?(Hash) -%>
 <%= k %>
 <%- v.keys.sort.each do |key| -%>


### PR DESCRIPTION
Since the merge of https://github.com/saz/puppet-ssh/pull/322 it wasn't possible to just manage server ssh::server or client ssh::client with this module.

This PR moves all parameters to the proper location (thanks to https://github.com/saz/puppet-ssh/pull/325 this module uses data in modules), which should make things work as before again.

I've also added a few more tests in this PR

Fixes #324 
Fixes #326
Fixes #329 