### PR TITLE
add support for client "match blocks"

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -32,6 +32,9 @@
 # @param default_options
 #   Default options to set, will be merged with options parameter
 #
+# @param match_block
+#   Add ssh match_block (with concat)
+#
 class ssh::client (
   Stdlib::Absolutepath $ssh_config,
   Hash                 $default_options,
@@ -41,6 +44,7 @@ class ssh::client (
   Hash                 $options              = {},
   Boolean              $use_augeas           = false,
   Array                $options_absent       = [],
+  Hash                 $match_block          = {},
 ) {
   if $use_augeas {
     $merged_options = sshclient_options_to_augeas_ssh_config($options, $options_absent, { 'target' => $ssh_config })
@@ -63,4 +67,6 @@ class ssh::client (
     Class['ssh::client::install']
     -> Class['ssh::client::config']
   }
+
+  create_resources('ssh::client::match_block', $match_block)
 }

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -12,13 +12,17 @@ class ssh::client::config {
   if $use_augeas {
     create_resources('ssh_config', $options)
   } else {
-    file { $ssh::client::ssh_config:
-      ensure  => file,
-      owner   => '0',
-      group   => '0',
-      mode    => '0644',
+    concat { $ssh::client::ssh_config:
+      ensure => present,
+      owner  => 0,
+      group  => 0,
+      mode   => '0644',
+    }
+
+    concat::fragment { 'ssh_config global config':
+      target  => $ssh::client::ssh_config,
       content => template("${module_name}/ssh_config.erb"),
-      require => Class['ssh::client::install'],
+      order   => '00',
     }
   }
 }

--- a/manifests/client/match_block.pp
+++ b/manifests/client/match_block.pp
@@ -1,0 +1,32 @@
+# @summary
+#   Add match_block to ssh client config (concat needed)
+#
+# @param options
+#   Options which should be set
+#
+# @param type
+#   Type of match_block, e.g. user, group, host, ...
+#
+# @param order
+#   Orders your settings within the config file
+#
+# @param target
+#   Sets the target file of the concat fragment
+#
+define ssh::client::match_block (
+  Hash                 $options = {},
+  Ssh::ClientMatch     $type    = 'user',
+  Integer              $order   = 50,
+  Stdlib::Absolutepath $target  = $ssh::client::ssh_config,
+) {
+  if $ssh::client::use_augeas {
+    fail('ssh::client::match_block() define not supported with use_augeas = true')
+  } else {
+    concat::fragment { "match_block ${name}":
+      target  => $target,
+      # same template may be used for ssh_config & sshd_config
+      content => template("${module_name}/sshd_match_block.erb"),
+      order   => 200+$order,
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,6 +120,9 @@
 # @param client_options
 #   Add dynamic options for ssh client config
 #
+# @param client_match_block
+#   Add match block for ssh client config
+#
 # @param users_client_options
 #   Add users options for ssh client config
 #
@@ -154,6 +157,7 @@ class ssh (
   Optional[Hash]                           $server_options          = undef,
   Hash                                     $server_match_block      = {},
   Optional[Hash]                           $client_options          = undef,
+  Hash                                     $client_match_block      = {},
   Hash                                     $users_client_options    = {},
   String                                   $version                 = 'present',
   Boolean                                  $storeconfigs_enabled    = true,
@@ -198,4 +202,5 @@ class ssh (
 
   create_resources('ssh::client::config::user', $users_client_options)
   create_resources('ssh::server::match_block', $server_match_block)
+  create_resources('ssh::client::match_block', $client_match_block)
 }

--- a/spec/acceptance/client_spec.rb
+++ b/spec/acceptance/client_spec.rb
@@ -7,22 +7,22 @@ describe 'ssh' do
     it_behaves_like 'an idempotent resource' do
       let(:manifest) do
         <<~PP
-        class { 'ssh':
-          client_options => {
-            'GlobalKnownHostsFile'      => "/var/lib/sss/pubconf/known_hosts",
-            'PubkeyAuthentication'      => "yes",
-            'GSSAPIAuthentication'      => "yes",
-            'GSSAPIDelegateCredentials' => "yes",
-          },
-          client_match_block => {
-            '!foo' => {
-              'type'    => 'user',
-              'options' => {
-                'ProxyCommand' => '/usr/bin/sss_ssh_knownhostsproxy -p %p %h',
+          class { 'ssh':
+            client_options => {
+              'GlobalKnownHostsFile'      => "/var/lib/sss/pubconf/known_hosts",
+              'PubkeyAuthentication'      => "yes",
+              'GSSAPIAuthentication'      => "yes",
+              'GSSAPIDelegateCredentials' => "yes",
+            },
+            client_match_block => {
+              '!foo' => {
+                'type'    => 'user',
+                'options' => {
+                  'ProxyCommand' => '/usr/bin/sss_ssh_knownhostsproxy -p %p %h',
+                },
               },
             },
-          },
-        }
+          }
         PP
       end
 
@@ -30,7 +30,8 @@ describe 'ssh' do
         it { is_expected.to be_file }
         it { is_expected.to be_owned_by 'root' }
         it { is_expected.to be_grouped_into 'root' }
-        it { is_expected.to be_mode '644' } # serverspec does not like a leading 0
+        it { is_expected.to be_mode '644' }  # serverspec does not like a leading 0
+
         its(:content) do
           is_expected.to match <<~SSH
             # File managed by Puppet
@@ -39,9 +40,12 @@ describe 'ssh' do
             PubkeyAuthentication yes
             GSSAPIAuthentication yes
             GSSAPIDelegateCredentials yes
+            Host *
+                HashKnownHosts yes
+                SendEnv LANG LC_*
             Match user !foo
                 ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h
-            SSH
+          SSH
         end
       end
     end

--- a/spec/acceptance/client_spec.rb
+++ b/spec/acceptance/client_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'ssh' do
+  context 'with client_match_block' do
+    it_behaves_like 'an idempotent resource' do
+      let(:manifest) do
+        <<~PP
+        class { 'ssh':
+          client_options => {
+            'GlobalKnownHostsFile'      => "/var/lib/sss/pubconf/known_hosts",
+            'PubkeyAuthentication'      => "yes",
+            'GSSAPIAuthentication'      => "yes",
+            'GSSAPIDelegateCredentials' => "yes",
+          },
+          client_match_block => {
+            '!foo' => {
+              'type'    => 'user',
+              'options' => {
+                'ProxyCommand' => '/usr/bin/sss_ssh_knownhostsproxy -p %p %h',
+              },
+            },
+          },
+        }
+        PP
+      end
+
+      describe file('/etc/ssh/ssh_config') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'root' }
+        it { is_expected.to be_grouped_into 'root' }
+        it { is_expected.to be_mode '644' } # serverspec does not like a leading 0
+        its(:content) do
+          is_expected.to match <<~SSH
+            # File managed by Puppet
+
+            GlobalKnownHostsFile /var/lib/sss/pubconf/known_hosts
+            PubkeyAuthentication yes
+            GSSAPIAuthentication yes
+            GSSAPIDelegateCredentials yes
+            Match user !foo
+                ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h
+            SSH
+        end
+      end
+    end
+  end
+end

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -12,7 +12,7 @@ describe 'ssh::client', type: 'class' do
         it { is_expected.to contain_class('ssh::knownhosts') }
         it { is_expected.to contain_class('ssh::client::config') }
         it { is_expected.to contain_class('ssh::client::install') }
-        it { is_expected.to contain_file('/etc/ssh/ssh_config') }
+        it { is_expected.to contain_concat('/etc/ssh/ssh_config') }
       end
 
       context 'with a different ssh_config location' do
@@ -22,7 +22,7 @@ describe 'ssh::client', type: 'class' do
           }
         end
 
-        it { is_expected.to contain_file('/etc/ssh/another_ssh_config') }
+        it { is_expected.to contain_concat('/etc/ssh/another_ssh_config') }
       end
 
       context 'with storeconfigs_enabled set to false' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -138,7 +138,7 @@ describe 'ssh', type: 'class' do
         it { is_expected.to contain_concat('/etc/ssh/sshd_config').with_validate_cmd(nil) }
         it { is_expected.to contain_resources('sshkey').with_purge(true) }
         it { is_expected.to contain_concat__fragment('global config').with_content(sshd_config_default) }
-
+        it { is_expected.to contain_concat__fragment('ssh_config global config').with_content(ssh_config_expected_default) }
         it { is_expected.to contain_package(client_package).with_ensure('installed') } if client_package
         it { is_expected.to contain_package(server_package).with_ensure('installed') } if server_package
       end

--- a/spec/defines/client/match_block_spec.rb
+++ b/spec/defines/client/match_block_spec.rb
@@ -23,14 +23,15 @@ describe 'ssh::client::match_block' do
         end
 
         it { is_expected.to compile.with_all_deps }
+
         it do
           is_expected.to contain_concat__fragment('match_block !foo').with(
             target: '/etc/ssh/ssh_config_foo',
             content: <<~SSH,
-            Match user !foo
-                ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h
+              Match user !foo
+                  ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h
             SSH
-            order: 250,
+            order: 250
           )
         end
       end

--- a/spec/defines/client/match_block_spec.rb
+++ b/spec/defines/client/match_block_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ssh::client::match_block' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let :pre_condition do
+        'include ssh'
+      end
+
+      context 'with !foo' do
+        let(:title) { '!foo' }
+        let(:params) do
+          {
+            'type' => 'user',
+            'options' => {
+              'ProxyCommand' => '/usr/bin/sss_ssh_knownhostsproxy -p %p %h',
+            },
+            'target' => '/etc/ssh/ssh_config_foo',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it do
+          is_expected.to contain_concat__fragment('match_block !foo').with(
+            target: '/etc/ssh/ssh_config_foo',
+            content: <<~SSH,
+            Match user !foo
+                ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h
+            SSH
+            order: 250,
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/sshclientmatch_spec.rb
+++ b/spec/type_aliases/sshclientmatch_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Ssh::ClientMatch' do
+  known_criteria = %w[
+    all
+    canonical
+    exec
+    final
+    host
+    localuser
+    originalhost
+    user
+  ]
+  it { is_expected.to allow_values(*known_criteria) }
+  it { is_expected.not_to allow_value(nil) }
+  it { is_expected.not_to allow_value('foo') }
+end

--- a/types/clientmatch.pp
+++ b/types/clientmatch.pp
@@ -1,0 +1,11 @@
+# OpenSSH client `Match` criteria. See `ssh_config(5)`
+type Ssh::ClientMatch = Enum[
+  'all',
+  'canonical',
+  'exec',
+  'final',
+  'host',
+  'localuser',
+  'originalhost',
+  'user',
+]


### PR DESCRIPTION
Rspec tests are limited in an attempt to avoid merge conflicts with #331.