### PR TITLE
fix support for negated ssh client match block criteria

### DIFF
--- a/spec/acceptance/client_spec.rb
+++ b/spec/acceptance/client_spec.rb
@@ -15,10 +15,17 @@ describe 'ssh' do
               'GSSAPIDelegateCredentials' => "yes",
             },
             client_match_block => {
-              '!foo' => {
-                'type'    => 'user',
+              'foo' => {
+                'type'    => '!localuser',
                 'options' => {
                   'ProxyCommand' => '/usr/bin/sss_ssh_knownhostsproxy -p %p %h',
+                },
+              },
+              'bar' => {
+                'type' => 'host',
+                'options' => {
+                  'ForwardX11' => 'no',
+                  'PasswordAuthentication' => 'yes',
                 },
               },
             },
@@ -43,7 +50,10 @@ describe 'ssh' do
             Host *
                 HashKnownHosts yes
                 SendEnv LANG LC_*
-            Match user !foo
+            Match host bar
+                ForwardX11 no
+                PasswordAuthentication yes
+            Match !localuser foo
                 ProxyCommand /usr/bin/sss_ssh_knownhostsproxy -p %p %h
           SSH
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -187,8 +187,8 @@ describe 'ssh', type: 'class' do
         let :params do
           {
             client_match_block: {
-              '!foo' => {
-                'type' => 'user',
+              'foo' => {
+                'type' => '!localuser',
                 'options' => {
                   'ProxyCommand' => '/usr/bin/sss_ssh_knownhostsproxy -p %p %h',
                 },
@@ -205,8 +205,8 @@ describe 'ssh', type: 'class' do
         end
 
         it do
-          is_expected.not_to contain_ssh__client__matchblock('!foo').with(
-            type: 'user',
+          is_expected.not_to contain_ssh__client__matchblock('foo').with(
+            type: '!localuser',
             options: {
               'ProxyCommand' => '/usr/bin/sss_ssh_knownhostsproxy -p %p %h',
             },

--- a/spec/type_aliases/sshclientmatch_spec.rb
+++ b/spec/type_aliases/sshclientmatch_spec.rb
@@ -4,13 +4,21 @@ require 'spec_helper'
 
 describe 'Ssh::ClientMatch' do
   known_criteria = %w[
+    !all
     all
+    !canonical
     canonical
+    !exec
     exec
+    !final
     final
+    !host
     host
+    !localuser
     localuser
+    !originalhost
     originalhost
+    !user
     user
   ]
   it { is_expected.to allow_values(*known_criteria) }

--- a/types/clientmatch.pp
+++ b/types/clientmatch.pp
@@ -1,11 +1,19 @@
 # OpenSSH client `Match` criteria. See `ssh_config(5)`
 type Ssh::ClientMatch = Enum[
+  '!all',
   'all',
+  '!canonical',
   'canonical',
+  '!exec',
   'exec',
+  '!final',
   'final',
+  '!host',
   'host',
+  '!localuser',
   'localuser',
+  '!originalhost',
   'originalhost',
+  '!user',
   'user',
 ]


### PR DESCRIPTION
In the client match block support added via #332, I had not correctly
interpreted `ssh_config(5).  A match block is negated by prepending a !
to the match type, not the parameters to the match type.  Per the man
page:

    Criteria may be negated by prepending an exclamation mark (‘!’).