### PR TITLE
ssh::server::instances: Implement support for service_ensure/service_enable

### DIFF
--- a/manifests/server/instances.pp
+++ b/manifests/server/instances.pp
@@ -1,4 +1,4 @@
-# @summary 
+# @summary
 #   Configure separate ssh server instances
 #
 # @param ensure
@@ -8,10 +8,10 @@
 #   Set options for the instance
 #
 # @param service_ensure
-#   Whether this instance service should be running or stopped
+#   Whether this instance service should be running or stopped, defaults to true when ensure is set to present, otherwise false
 #
 # @param service_enable
-#   Whether this instance service should be started at boot
+#   Whether this instance service should be started at boot. Will be added automatically if ensure is running/removed if ensure is stopped
 #
 # @param validate_config_file
 #   Validate config file before applying
@@ -28,8 +28,8 @@
 define ssh::server::instances (
   Enum[present, absent]          $ensure                    = present,
   Hash                           $options                   = {},
-  Stdlib::Ensure::Service        $service_ensure            = 'running',
-  Boolean                        $service_enable            = true,
+  Stdlib::Ensure::Service        $service_ensure            = $ensure ? { 'present' => 'running', 'absent' => 'stopped' },
+  Boolean                        $service_enable            = ($service_ensure == 'running'),
   Boolean                        $validate_config_file      = false,
   Stdlib::Absolutepath           $sshd_instance_config_file = "${ssh::server::sshd_dir}/sshd_config.${title}",
   Stdlib::Absolutepath           $sshd_binary               = $ssh::server::sshd_binary,
@@ -75,8 +75,8 @@ define ssh::server::instances (
 
     systemd::unit_file { "${title}.service":
       content => template("${module_name}/ssh_instance_service.erb"),
-      active  => true,
-      enable  => true,
+      active  => ($service_ensure == 'running'),
+      enable  => $service_enable,
     }
   } else {
     fail ("Operating System ${facts['os']['name']} not supported, because Systemd is not available")

--- a/spec/defines/server/instances_spec.rb
+++ b/spec/defines/server/instances_spec.rb
@@ -3,131 +3,154 @@
 require 'spec_helper'
 
 describe 'ssh::server::instances' do
-  context 'with sftp_server present' do
-    let(:title) { 'sftp_server' }
-    let :pre_condition do
-      'include ssh'
-    end
-    let(:params) do
-      {
-        'ensure' => 'present',
-        'options' => {
-          'sshd_config' => {
-            'Port' => 8022,
-            'Protocol' => 2,
-            'AddressFamily' => 'any',
-            'HostKey' => '/etc/ssh/ssh_host_rsa_key',
-            'SyslogFacility' => 'AUTH',
-            'LogLevel' => 'INFO',
-            'LoginGraceTime' => 120,
-            'PermitRootLogin' => 'no',
-            'StrictModes' => 'yes',
-            'PubkeyAuthentication' => 'yes',
-            'HostbasedAuthentication' => 'no',
-            'IgnoreUserKnownHosts' => 'no',
-            'IgnoreRhosts' => 'yes',
-            'PasswordAuthentication' => 'yes',
-            'ChallengeResponseAuthentication' => 'no',
-            'GSSAPIAuthentication' => 'no',
-            'GSSAPIKeyExchange' => 'no',
-            'GSSAPICleanupCredentials' => 'yes',
-            'UsePAM' => 'yes',
-            'AcceptEnv' => %w[LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION LC_ALL],
-            'AllowTcpForwarding' => 'no',
-            'X11Forwarding' => 'no',
-            'X11UseLocalhost' => 'yes',
-            'PrintMotd' => 'yes',
-            'TCPKeepAlive' => 'yes',
-            'ClientAliveInterval' => 0,
-            'ClientAliveCountMax' => 0,
-            'UseDNS' => 'no',
-            'PermitTunnel' => 'no',
-            'Banner' => '/etc/ssh/sshd_banner.txt',
-            'XAuthLocation' => '/usr/bin/xauth',
-            'Subsystem' => 'sftp /usr/libexec/openssh/sftp-server',
-            'Ciphers' => %w[aes128-ctr aes192-ctr aes256-ctr aes128-cbc 3des-cbc aes192-cbc aes256-cbc],
-            'AllowGroups' => 'root lclssh ssh_all_systems VmAdmins',
-          },
-          'sshd_service_options' => '',
-          'match_blocks' => {
-            '*,!ssh_exempt_ldap_authkey,!sshlokey' => {
-              'type' => 'group',
-              'options' => {
-                'AuthorizedKeysCommand' => '/usr/local/bin/getauthkey',
-                'AuthorizedKeysCommandUser' => 'nobody',
-                'AuthorizedKeysFile' => '/dev/null',
-              },
-            },
-            'ssh_deny_pw_auth,sshdnypw' => {
-              'type' => 'group',
-              'options' => {
-                'KbdInteractiveAuthentication' => 'no',
-                'PasswordAuthentication' => 'no',
-              },
-            },
-          },
-        },
-        'service_ensure' => 'running',
-        'service_enable' => true,
-        'validate_config_file' => true,
-      }
-    end
-
-    on_supported_os.each do |os, os_facts|
-      context "on #{os}" do
-        let(:facts) { os_facts }
-
-        if os_facts[:kernel] == 'Linux'
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_concat('/etc/ssh/sshd_config.sftp_server') }
-          it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
-          it { is_expected.to contain_ssh__server__match_block('ssh_deny_pw_auth,sshdnypw') }
-          it { is_expected.to contain_ssh__server__match_block('*,!ssh_exempt_ldap_authkey,!sshlokey') }
-          it { is_expected.to contain_systemd__unit_file('sftp_server.service') }
-          it { is_expected.to contain_service('sftp_server.service') }
-        else
-          it { is_expected.to compile.and_raise_error(%r{not supported, because Systemd is not available}) }
-        end
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}", if: os_facts[:kernel] == 'Linux' do
+      let(:facts) { os_facts }
+      let(:title) { 'sftp_server' }
+      let :pre_condition do
+        'include ssh'
       end
-    end
-  end
 
-  context 'minimal setup' do
-    let(:title) { 'sftp_server' }
-    let :pre_condition do
-      'include ssh'
-    end
-    let(:params) do
-      {
-        'ensure' => 'present',
-        'options' => {
-          'sshd_config' => {
-            'Port' => 8022,
-            'Protocol' => 2,
-            'AddressFamily' => 'any',
-            'HostKey' => '/etc/ssh/ssh_host_rsa_key',
-            'SyslogFacility' => 'AUTH',
-            'LogLevel' => 'INFO',
-            'PermitRootLogin' => 'no',
-          },
-          'sshd_service_options' => '',
-          'match_blocks' => {},
-        },
-      }
-    end
-
-    on_supported_os.each do |os, os_facts|
-      context "on #{os}" do
-        let(:facts) { os_facts }
-
-        if os_facts[:kernel] == 'Linux'
-          it { is_expected.to compile.with_all_deps }
-          it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
-          it { is_expected.to contain_systemd__unit_file('sftp_server.service') }
-          it { is_expected.to contain_service('sftp_server.service') }
-        else
-          it { is_expected.to compile.and_raise_error(%r{not supported, because Systemd is not available}) }
+      context 'with sftp_server present' do
+        let(:params) do
+          {
+            'ensure' => 'present',
+            'options' => {
+              'sshd_config' => {
+                'Port' => 8022,
+                'Protocol' => 2,
+                'AddressFamily' => 'any',
+                'HostKey' => '/etc/ssh/ssh_host_rsa_key',
+                'SyslogFacility' => 'AUTH',
+                'LogLevel' => 'INFO',
+                'LoginGraceTime' => 120,
+                'PermitRootLogin' => 'no',
+                'StrictModes' => 'yes',
+                'PubkeyAuthentication' => 'yes',
+                'HostbasedAuthentication' => 'no',
+                'IgnoreUserKnownHosts' => 'no',
+                'IgnoreRhosts' => 'yes',
+                'PasswordAuthentication' => 'yes',
+                'ChallengeResponseAuthentication' => 'no',
+                'GSSAPIAuthentication' => 'no',
+                'GSSAPIKeyExchange' => 'no',
+                'GSSAPICleanupCredentials' => 'yes',
+                'UsePAM' => 'yes',
+                'AcceptEnv' => %w[LANG LC_CTYPE LC_NUMERIC LC_TIME LC_COLLATE LC_MONETARY LC_MESSAGES LC_PAPER LC_NAME LC_ADDRESS LC_TELEPHONE LC_MEASUREMENT LC_IDENTIFICATION LC_ALL],
+                'AllowTcpForwarding' => 'no',
+                'X11Forwarding' => 'no',
+                'X11UseLocalhost' => 'yes',
+                'PrintMotd' => 'yes',
+                'TCPKeepAlive' => 'yes',
+                'ClientAliveInterval' => 0,
+                'ClientAliveCountMax' => 0,
+                'UseDNS' => 'no',
+                'PermitTunnel' => 'no',
+                'Banner' => '/etc/ssh/sshd_banner.txt',
+                'XAuthLocation' => '/usr/bin/xauth',
+                'Subsystem' => 'sftp /usr/libexec/openssh/sftp-server',
+                'Ciphers' => %w[aes128-ctr aes192-ctr aes256-ctr aes128-cbc 3des-cbc aes192-cbc aes256-cbc],
+                'AllowGroups' => 'root lclssh ssh_all_systems VmAdmins',
+              },
+              'sshd_service_options' => '',
+              'match_blocks' => {
+                '*,!ssh_exempt_ldap_authkey,!sshlokey' => {
+                  'type' => 'group',
+                  'options' => {
+                    'AuthorizedKeysCommand' => '/usr/local/bin/getauthkey',
+                    'AuthorizedKeysCommandUser' => 'nobody',
+                    'AuthorizedKeysFile' => '/dev/null',
+                  },
+                },
+                'ssh_deny_pw_auth,sshdnypw' => {
+                  'type' => 'group',
+                  'options' => {
+                    'KbdInteractiveAuthentication' => 'no',
+                    'PasswordAuthentication' => 'no',
+                  },
+                },
+              },
+            },
+            'service_ensure' => 'running',
+            'service_enable' => true,
+            'validate_config_file' => true,
+          }
         end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat('/etc/ssh/sshd_config.sftp_server') }
+        it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
+        it { is_expected.to contain_ssh__server__match_block('ssh_deny_pw_auth,sshdnypw') }
+        it { is_expected.to contain_ssh__server__match_block('*,!ssh_exempt_ldap_authkey,!sshlokey') }
+        it { is_expected.to contain_systemd__unit_file('sftp_server.service') }
+        it { is_expected.to contain_service('sftp_server.service') }
+      end
+
+      context 'with minimal params' do
+        let(:params) do
+          {
+            'ensure' => 'present',
+            'options' => {
+              'sshd_config' => {
+                'Port' => 8022,
+                'Protocol' => 2,
+                'AddressFamily' => 'any',
+                'HostKey' => '/etc/ssh/ssh_host_rsa_key',
+                'SyslogFacility' => 'AUTH',
+                'LogLevel' => 'INFO',
+                'PermitRootLogin' => 'no',
+              },
+              'sshd_service_options' => '',
+              'match_blocks' => {},
+            },
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
+        it { is_expected.to contain_systemd__unit_file('sftp_server.service').with_enable(true).with_active(true) }
+        it { is_expected.to contain_service('sftp_server.service').with_ensure(true).with_enable(true) }
+      end
+
+      context 'with minimal example and ensure stopped' do
+        let(:params) do
+          {
+            'ensure' => 'absent',
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
+        it { is_expected.to contain_systemd__unit_file('sftp_server.service').with_enable(false).with_active(false) }
+        it { is_expected.to contain_service('sftp_server.service').with_enable(false).with_ensure(false) }
+      end
+
+      context 'with minimal example and service stopped' do
+        let(:params) do
+          {
+            'service_ensure' => 'stopped',
+            'service_enable' => true,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
+        it { is_expected.to contain_systemd__unit_file('sftp_server.service').with_enable(true).with_active(false) }
+        it { is_expected.to contain_service('sftp_server.service').with_enable(true).with_ensure(false) }
+      end
+
+      context 'with minimal example and service running but not in autostart' do
+        let(:params) do
+          {
+            'ensure' => 'present',
+            'service_enable' => false,
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat__fragment('sshd instance sftp_server config') }
+        it { is_expected.to contain_systemd__unit_file('sftp_server.service').with_enable(false).with_active(true) }
+        it { is_expected.to contain_service('sftp_server.service').with_enable(false).with_ensure(true) }
       end
     end
   end


### PR DESCRIPTION
previously, the defined resource had the service_ensure and
service_enable parameters, but didn't use them. This change:
* makes service_ensure depended on ensure
* makes service_enable depended on service_ensure
* passes service_ensure/service_enable to systemd::unit_file
* refactores the unit tests to make them faster