### PR TITLE
Add data file for OpenBSD

### DIFF
--- a/data/OpenBSD.yaml
+++ b/data/OpenBSD.yaml
@@ -1,19 +1,14 @@
 ---
 ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/sbin/sshd'
 ssh::server::sshd_config: '/etc/ssh/sshd_config'
 ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/sftp-server'
 ssh::server::host_priv_key_group: 0
-
 ssh::server::default_options:
   ChallengeResponseAuthentication: 'no'
-  X11Forwarding                  : 'yes'
-  PrintMotd                      : 'no'
-  AcceptEnv                      : 'LANG LC_*'
-  Subsystem                      : "sftp %{lookup('ssh::sftp_server_path')}"
-
-ssh::client::default_options:
-  'Host *':
-    SendEnv: 'LANG LC_*'
-    HashKnownHosts: 'yes'
+  X11Forwarding: 'yes'
+  PrintMotd: 'no'
+  AcceptEnv: 'LANG LC_*'
+  Subsystem: "sftp %{lookup('ssh::sftp_server_path')}"


### PR DESCRIPTION
copied over the FreeBSD.yaml file, had to add the

ssh::server::default_options

as there's no PAM on OpenBSD, which prevented to start sshd.

tested on a puppet5 puppetmaster as well as puppet 5 and puppet 7 agents