### PR TITLE
Add AIX support

### DIFF
--- a/data/AIX.yaml
+++ b/data/AIX.yaml
@@ -1,0 +1,16 @@
+---
+ssh::server::sshd_dir: '/etc/ssh'
+ssh::server::sshd_binary: '/usr/sbin/sshd'
+ssh::server::sshd_config: '/etc/ssh/sshd_config'
+ssh::server::ssh_config: '/etc/ssh/ssh_config'
+ssh::server::ssh_known_hosts: '/etc/ssh/ssh_known_hosts'
+ssh::server::service_name: 'sshd'
+ssh::sftp_server_path: '/usr/sbin/sftp-server'
+ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  AcceptEnv: 'LANG LC_*'
+  ChallengeResponseAuthentication: 'no'
+  PrintMotd: 'no'
+  Subsystem: "sftp %{lookup('ssh::sftp_server_path')}"
+  UsePAM: 'no'
+  X11Forwarding: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -65,7 +65,7 @@
       "operatingsystemrelease": [
         "18.04",
         "20.04",
-	"22.04"
+        "22.04"
       ]
     },
     {
@@ -111,6 +111,9 @@
     },
     {
       "operatingsystem": "Archlinux"
+    },
+    {
+      "operatingsystem": "AIX"
     }
   ],
   "requirements": [


### PR DESCRIPTION
`server_package_name` and `client_package_name` are not set, as the package is builtin.

Signed-off-by: Bryan Hundven <bryanhundven@skytap.com>