### PR TITLE
Fix for service name on latest versions of opensuse.

### DIFF
--- a/data/Suse.yaml
+++ b/data/Suse.yaml
@@ -5,5 +5,6 @@ ssh::server::sshd_dir: '/etc/ssh'
 ssh::server::sshd_binary: '/usr/sbin/sshd'
 ssh::server::sshd_config: '/etc/ssh/sshd_config'
 ssh::server::sshd_environments_file: '/etc/sysconfig/ssh'
+ssh::server::service_name: 'sshd'
 ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::host_priv_key_group: 0


### PR DESCRIPTION
This is a fix for the service name on latest versions of Opensuse (Tested on Opensuse Tumbleweed). Currently it fails with this error

```sh
==> default: Error: Systemd start for svc:/network/ssh:default failed!
==> default: journalctl log for svc:/network/ssh:default:
==> default: Invalid unit name "svc:/network/ssh:default" escaped as "svc:-network-ssh:default" (maybe you should use systemd-escape?).
```