### PR TITLE
Support assigning multiple tags to a hostkey

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,22 @@ class YOURCUSTOMCLASS {
 }
 ```
 
+## Tag hostkey
+
+Assign tags to exported `sshkey` resources (when `ssh::storeconfigs_enabled` is set to `true`).
+
+```yaml
+ssh::hostkeys::tags:
+  - hostkey_group1
+  - hostkey_group2
+```
+
+Host keys then can be imported using:
+
+```puppet
+Sshkey <<| tag == "hostkey_group1" |>>
+```
+
 ## Excluding network interfaces or ipaddresses
 
 Use hiera to exclude interfaces or ipaddresses from hostkey inclusion

--- a/spec/classes/hostkeys_spec.rb
+++ b/spec/classes/hostkeys_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'ssh::hostkeys', type: 'class' do
+  _, os_facts = on_supported_os.first
+
+  let(:facts) { os_facts }
+
+  context 'with tags' do
+    let(:params) do
+      {
+        tags: %w[group1 group2]
+      }
+    end
+
+    %w[dsa rsa ecdsa ed25519].each do |key_type|
+      it {
+        expect(exported_resources).to contain_sshkey("foo.example.com_#{key_type}").
+          with(
+            ensure: 'present',
+            type: %r{^#{key_type}},
+            tag: %w[group1 group2]
+          )
+      }
+    end
+  end
+
+  context 'with storeconfigs_group' do
+    let(:params) do
+      {
+        storeconfigs_group: 'server_group',
+      }
+    end
+
+    %w[dsa rsa ecdsa ed25519].each do |key_type|
+      it {
+        expect(exported_resources).to contain_sshkey("foo.example.com_#{key_type}").
+          with(
+            ensure: 'present',
+            type: %r{^#{key_type}},
+            tag: %w[hostkey_all hostkey_server_group]
+          )
+      }
+    end
+  end
+
+  context 'with storeconfigs_group and tags' do
+    let(:params) do
+      {
+        storeconfigs_group: 'server_group',
+        tags: %w[group1 group2],
+      }
+    end
+
+    %w[dsa rsa ecdsa ed25519].each do |key_type|
+      it {
+        expect(exported_resources).to contain_sshkey("foo.example.com_#{key_type}").
+          with(
+            ensure: 'present',
+            type: %r{^#{key_type}},
+            tag: %w[hostkey_all hostkey_server_group group1 group2]
+          )
+      }
+    end
+  end
+end


### PR DESCRIPTION
Currently only one tag (`storeconfigs_group`) can be assigned to a `hostkey`.

Resolves: #307 