### PR TITLE
docs: use correct heading layout for changelog file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,92 +1,141 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [11.0.0]
+
 ### Removed
+
 - BREAKING CHANGE: drop support for puppet 6
+
 ### Changed
+
 - puppetlabs/concat: Allow 9.x (#354)
 - puppet/systemd: Allow 5.x (#354)
 - puppetlabs/stdlib: Require 9.x (#354)
+
 ### Added
+
 - add Debian 12 as supported OS
 
 ## [10.2.0]
+
 ### Changed
+
 - bump puppetlabs/concat to < 9.0.0 (#352)
 - Replace deprecated functions (#350)
 
 ## [10.1.0]
+
 ### Added
+
 - Support assigning multiple tags to a hostkey (#345)
 - Add AIX support (#341)
+
 ### Changed
+
 - bump puppet/systemd to < 5.0.0 (#344)
+
 ### Fixed
+
 - Fix for service name on latest versions of opensuse. (#343)
 
 ## [10.0.0]
+
 ### Added
+
 - Add support for client "match blocks" (#332, #333)
 - Add data file for OpenBSD (#339)
 - Add support for service_ensure/service_enable in `ssh::server::instances` (#338)
+
 ### Changed
+
 - Use hiera instead of params.pp (#325, #328)
+
 ### Fixed
+
 - Fix parameter lookup for `ssh::server` and `ssh::client` (#331)
 
 ## [9.0.0]
+
 ### Added
+
 - Support for multiple instances (#318, #319, #321) - Thanks!
+
 ### Changed
+
 - "hostkeys.pp" isn't marked private anymore (#317)
 
 ## [8.0.0]
+
 ### Changed
+
 - update path to sftp server on Gentoo (#315, breaking change)
 
 ## [7.0.2]
+
 ### Added
+
 - allow stdlib < 9.0.0 (#314)
 
 ## [7.0.1]
+
 ### Fixed
+
 - ssh_config: Don't populate options that are set to undef (#312)
 
 ## [7.0.0]
+
 ### Fixed
+
 - Fix grammar and spelling in various places
+
 ### Changed
+
 - Use GitHub Actions instead of TravisCI
 - Update module dependencies
+
 ### Removed
+
 - Dropped support for puppet 4 and 5 (Breaking Change)
 
 ## [6.2.0]
+
 ### Changed
+
 - support older facter versions (#293)
 
 ## [6.1.0]
+
 ### Fixed
+
 - Fix absolute class name includes
 - Use gid 0 instead of group name for $host_priv_key_group (#289)
 - Sort hostkeys (#288)
 - Do not show diff when installing a ssh private host key (#283)
 - Don't populate options which have a value of `undef` (#281)
+
 ### Added
+
 - document exclusion of interfaces and ipaddresses within hostkeys.pp (#267)
 - add parameter to use trusted facts to hostkeys.pp (#226)
 
 ## [6.0.0]
+
 ### Fixed
+
 - don't fail at deep_merge if hiera data not available, see #272
 - Fix typo in match_block example in README, see #271, #273
+
 ### Added
+
 - Add CHANGELOG (starting with this release), see #222
 - Test module with Puppet 6.1, see #269
+
 ### Changed
+
 - Convert `ipaddresses` to 4x API namespaced function, see #270
 - Allow `puppetlabs` `stdlib` and `concat` 6.x, see #280


### PR DESCRIPTION
I've tried getting a correct changelog for this project using Renovate, but it seems it's been unable to parse the `CHANGELOG.md` file correctly.

I think it's because the markdown is not valid and it needs to have empty lines between the headings.  Look at the upstream changelog as reference: https://github.com/olivierlacan/keep-a-changelog/blob/main/CHANGELOG.md

Also, the spec itself uses empty lines: https://keepachangelog.com/en/1.1.0/  - I hope that GitHub will also add links to the versions like the upstream file has.  Seeing as the markdown has not `[]()` around the tags.