### PR TITLE
write ciphers,macs and kex as comma-separated string

### DIFF
--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -40,9 +40,13 @@ ListenAddress <%= listen %>
 <%- v.keys.sort.each do |key| -%>
     <%- value = v[key] -%>
     <%- if value.is_a?(Array) -%>
+    <%- if ['ciphers', 'macs', 'kexalgorithms'].include?(key.downcase) -%>
+    <%= key %> <%= value.join(',') %>
+    <%- else -%>
     <%- value.each do |a| -%>
     <%- if a != '' && a != nil -%>
     <%= key %> <%= bool2str(a) %>
+    <%- end -%>
     <%- end -%>
     <%- end -%>
     <%- elsif value != '' && value != nil -%>
@@ -51,9 +55,13 @@ ListenAddress <%= listen %>
 <%- end -%>
 <%- else -%>
 <%- if v.is_a?(Array) -%>
+<%- if ['ciphers', 'macs', 'kexalgorithms'].include?(k.downcase) -%>
+<%= k %> <%= v.join(',') %>
+<%- else -%>
 <%- v.each do |a| -%>
 <%- if a != '' && a != nil -%>
 <%= k %> <%= bool2str(a) %>
+<%- end -%>
 <%- end -%>
 <%- end -%>
 <%- elsif v != nil and v != '' -%>


### PR DESCRIPTION
As the man page of sshd_config(5) describes:
"Multiple ciphers/macs/kexalgorithms must be comma-separated." Using an array or YAML list for ciphers/mac/kex results in multiple entries in sshd_config. If multiple entries are set in sshd_config, sshd takes only the first one.

Fixes #361

With this fix, we can write the server_options for ciphers/macs/kexalgorithms as an array or as yaml list in hiera, that increases the readability a lot :)
@bastelfreak @SimonHoenscheid could you please take a look? 
# Example
```
class { 'ssh':
  storeconfigs_enabled => false,
  server_options => {
    'Ciphers'       => [ 'aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc' ],
    'Macs'          => [ 'hmac-sha2-512-etm@openssh.com', 'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512', 'hmac-sha2-256' ],
    'KexAlgorithms' => [ 'curve25519-sha256', 'curve25519-sha256@libssh.org', 'diffie-hellman-group14-sha256', 'diffie-hellman-group16-sha512' ],
  },
}
```
**generated sshd_config**
```
# File is managed by Puppet

AcceptEnv LANG LC_*
ChallengeResponseAuthentication no
Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc
KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512
Macs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
PrintMotd no
Subsystem sftp /usr/libexec/openssh/sftp-server
UsePAM yes
X11Forwarding yes
```
**sshd -T**
```
sshd -T | grep -E "(^cipher|^kexal|^mac)"
ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc
macs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256
kexalgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512
```
