### PR TITLE
Use the package resource as there is only one package

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -7,10 +7,8 @@ class ssh::client::install {
   assert_private()
 
   if $ssh::client::client_package_name {
-    stdlib::ensure_packages([
-        $ssh::client::client_package_name,
-      ], {
-        'ensure' => $ssh::client::ensure,
-    })
+    package { $ssh::client::client_package_name:
+      ensure => $ssh::client::ensure,
+    }
   }
 }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -7,6 +7,6 @@ class ssh::server::install {
   assert_private()
 
   if $ssh::server::server_package_name {
-    package($ssh::server::server_package_name, { ensure => $ssh::server::ensure })
+    package { $ssh::server::server_package_name: ensure => $ssh::server::ensure }
   }
 }

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -7,10 +7,6 @@ class ssh::server::install {
   assert_private()
 
   if $ssh::server::server_package_name {
-    stdlib::ensure_packages ([
-        $ssh::server::server_package_name,
-      ], {
-        'ensure' => $ssh::server::ensure,
-    })
+    package($ssh::server::server_package_name, { ensure => $ssh::server::ensure })
   }
 }


### PR DESCRIPTION
Reducing the dependency on stdlib, this module could just use the built-in `package` resource.

This PR implements that.