### PR TITLE
Allow User to add additonal systemd options to instances

### DIFF
--- a/manifests/server/instances.pp
+++ b/manifests/server/instances.pp
@@ -37,9 +37,11 @@ define ssh::server::instances (
 ) {
   include ssh::server
 
-  $sshd_instance_config       = assert_type(Hash, pick($options['sshd_config'], {}))
-  $sshd_instance_matchblocks  = assert_type(Hash, pick($options['match_blocks'], {}))
-  $sshd_service_options       = $options['sshd_service_options']
+  $sshd_instance_config             = assert_type(Hash, pick($options['sshd_config'], {}))
+  $sshd_instance_matchblocks        = assert_type(Hash, pick($options['match_blocks'], {}))
+  $sshd_service_options             = $options['sshd_service_options']
+  $sshd_additional_service_options  = $options['sshd_additional_service_options']
+
   #check if server is a linux
   if $facts['kernel'] == 'Linux' {
     case $validate_config_file {

--- a/templates/ssh_instance_service.erb
+++ b/templates/ssh_instance_service.erb
@@ -9,6 +9,19 @@ After=network.target sshd-keygen.service
 Wants=sshd-keygen.service
 
 [Service]
+<%- if @sshd_additional_service_options -%>
+<%- @sshd_additional_service_options.each do |k,v| -%>
+<%- if v.is_a?(Array) -%>
+<%- v.each do |a| -%>
+<%- if a != '' && a != nil -%>
+<%= k %>=<%= bool2str(a) %>
+<%- end -%>
+<%- end -%>
+<%- elsif v != '' && v != nil -%>
+<%= k %>=<%= bool2str(v) %>
+<%- end -%>
+<%- end -%>
+<%- end -%>
 <% if @sshd_environments_file %>
 EnvironmentFile=<%= @sshd_environments_file -%>
 <% end %>


### PR DESCRIPTION
I want to use additional service options, when I create a ssh instance.
Right now it is restricted to only the given service options which are defined in the template.
To enable this feature I adjusted the template.

Example config:

  ssh-test:
    options:
      sshd_additional_service_options:
        IPAccounting: 'yes'
        IPAddressDeny: 'any'
        IPAddressAllow:
          - "1.2.3.4/24"
          - "5.6.7.8/24"