### PR TITLE
Add support for sshd_config include files

### DIFF
--- a/data/RedHat-9.yaml
+++ b/data/RedHat-9.yaml
@@ -1,0 +1,5 @@
+---
+ssh::server::include_dir: '/etc/ssh/sshd_config.d'
+ssh::server::config_files:
+  50-redhat:
+    include: '/etc/crypto-policies/back-ends/opensshserver.config'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -16,7 +16,9 @@ hierarchy:
     path: '%{facts.os.name}.yaml'
 
   - name: 'Major Version'
-    path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
+    paths:
+      - '%{facts.os.name}-%{facts.os.release.major}.yaml'
+      - '%{facts.os.family}-%{facts.os.release.major}.yaml'
 
   - name: 'Major Version with architecture'
     path: '%{facts.os.name}-%{facts.os.release.major}-%{facts.os.architecture}.yaml'

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -32,6 +32,18 @@
 # @param ensure
 #   Ensurable param to ssh server
 #
+# @param include_dir
+#   Path to sshd include directory.
+#
+# @param include_dir_mode
+#   Mode to set on the sshd include directory.
+#
+# @param include_dir_purge
+#   Purge the include directory if true.
+#
+# @param config_files
+#   Hash of config files to add to the ssh include directory.
+#
 # @param storeconfigs_enabled
 #   Host keys will be collected and distributed unless storeconfigs_enabled is false.
 #
@@ -68,6 +80,10 @@ class ssh::server (
   Integer                        $host_priv_key_group,
   Hash                           $default_options,
   Enum[present,absent,latest]    $ensure                 = present,
+  Optional[Stdlib::Absolutepath] $include_dir            = undef,
+  Stdlib::Filemode               $include_dir_mode       = '0700',
+  Boolean                        $include_dir_purge      = true,
+  Hash[String, Hash]             $config_files           = {},
   Boolean                        $storeconfigs_enabled   = true,
   Hash                           $options                = {},
   Boolean                        $validate_sshd_file     = false,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -7,6 +7,7 @@ class ssh::server::config {
   assert_private()
 
   $options = $ssh::server::merged_options
+  $include_dir = $ssh::server::include_dir
 
   case $ssh::server::validate_sshd_file {
     true: {
@@ -44,6 +45,23 @@ class ssh::server::config {
       target  => $ssh::server::sshd_config,
       content => template("${module_name}/sshd_config.erb"),
       order   => '00',
+    }
+  }
+
+  if $ssh::server::include_dir {
+    file { $ssh::server::include_dir:
+      ensure  => directory,
+      owner   => 0,
+      group   => 0,
+      mode    => $ssh::server::include_dir_mode,
+      purge   => $ssh::server::include_dir_purge,
+      recurse => true,
+    }
+
+    $ssh::server::config_files.each |$file, $params| {
+      ssh::server::config_file { $file:
+        * => $params,
+      }
     }
   }
 

--- a/manifests/server/config_file.pp
+++ b/manifests/server/config_file.pp
@@ -1,0 +1,46 @@
+# @summary Resource type for managing a config file in the include dir.
+#
+# @param mode
+#   File mode for the config file.
+#
+# @param include
+#   Absolute path to config file to include at the top of the config file. This
+#   is intended for including files not managed by this module (crypto policies).
+#
+# @param options
+#   Dynamic hash for openssh server option
+#
+define ssh::server::config_file (
+  Stdlib::Absolutepath $path = "${ssh::server::include_dir}/${name}.conf",
+  Stdlib::Filemode $mode = $ssh::server::sshd_config_mode,
+  Optional[Stdlib::Absolutepath] $include = undef,
+  Hash $options = {},
+) {
+  if !$ssh::server::include_dir {
+    fail('ssh::server::config_file() define not supported if ssh::server::include_dir not set')
+  }
+
+  case $ssh::server::validate_sshd_file {
+    true: {
+      $sshd_validate_cmd = '/usr/sbin/sshd -tf %'
+    }
+    default: {
+      $sshd_validate_cmd = undef
+    }
+  }
+
+  concat { $path:
+    ensure       => present,
+    owner        => 0,
+    group        => 0,
+    mode         => $mode,
+    validate_cmd => $sshd_validate_cmd,
+    notify       => Service[$ssh::server::service_name],
+  }
+
+  concat::fragment { "sshd_config_file ${title}":
+    target  => $path,
+    content => template("${module_name}/sshd_config.erb"),
+    order   => '00',
+  }
+}

--- a/templates/sshd_config.erb
+++ b/templates/sshd_config.erb
@@ -11,6 +11,12 @@
     end
   end
 -%>
+<%- if @include_dir -%>
+Include <%= @include_dir %>/*.conf
+<%- end -%>
+<%- if @include -%>
+Include <%= @include %>
+<%- end -%>
 <%- if addressfamily = @options.delete('AddressFamily') -%>
 AddressFamily <%= addressfamily %>
 <%- end -%>


### PR DESCRIPTION
Add include_dir parameter for specifying an include directory at the top of sshd_config.

Add ssh::server::config_file resource type for creating config files within the include directory. Provides include parameter for including externally managed config files. This is primarily intended for including crypto policies in RedHat 9 family.

Add data for RedHat 9 family to add include directory and config file to load crypto policies for OpenSSH server by default.