### PR TITLE
Purge and Recurse should be set together

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -55,7 +55,7 @@ class ssh::server::config {
       group   => 0,
       mode    => $ssh::server::include_dir_mode,
       purge   => $ssh::server::include_dir_purge,
-      recurse => true,
+      recurse => $ssh::server::include_dir_purge,
     }
 
     $ssh::server::config_files.each |$file, $params| {


### PR DESCRIPTION
If you for whatever reason decide to change the value of purge, recurse should change with it.

This is nothing new and the solution as it's implemented here is the same I have seen in other popular modules (saz-sudo, ghoneycutt-ssh) regarding the relation between purge and recurse. If you don't you can get unexpected behaviour.

Related to #390