### PR TITLE
ssh_instance: write ciphers,macs and kex as comma-separated string

### DIFF
--- a/templates/ssh_instance.erb
+++ b/templates/ssh_instance.erb
@@ -40,9 +40,13 @@ ListenAddress <%= listen %>
 <%- v.keys.sort.each do |key| -%>
     <%- value = v[key] -%>
     <%- if value.is_a?(Array) -%>
+    <%- if ['ciphers', 'macs', 'kexalgorithms'].include?(key.downcase) -%>
+    <%= key %> <%= value.join(',') %>
+    <%- else -%>
     <%- value.each do |a| -%>
     <%- if a != '' && a != nil -%>
     <%= key %> <%= bool2str(a) %>
+    <%- end -%>
     <%- end -%>
     <%- end -%>
     <%- elsif value != '' && value != nil -%>
@@ -51,9 +55,13 @@ ListenAddress <%= listen %>
 <%- end -%>
 <%- else -%>
 <%- if v.is_a?(Array) -%>
+<%- if ['ciphers', 'macs', 'kexalgorithms'].include?(k.downcase) -%>
+<%= k %> <%= v.join(',') %>
+<%- else -%>
 <%- v.each do |a| -%>
 <%- if a != '' && a != nil -%>
 <%= k %> <%= bool2str(a) %>
+<%- end -%>
 <%- end -%>
 <%- end -%>
 <%- elsif v != nil and v != '' -%>


### PR DESCRIPTION
As the man page of sshd_config(5) describes:
"Multiple ciphers/macs/kexalgorithms must be comma-separated." Using an array or YAML list for ciphers/mac/kex results in multiple entries in sshd_config. If multiple entries are set in sshd_config, sshd takes only the first one.

Fixes #400