### PR TITLE
Deprecated challenge response authentication

### DIFF
--- a/data/Amazon.yaml
+++ b/data/Amazon.yaml
@@ -9,3 +9,5 @@ ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/openssh/sftp-server'
 ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/Archlinux.yaml
+++ b/data/Archlinux.yaml
@@ -8,3 +8,5 @@ ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::service_name: 'sshd.service'
 ssh::sftp_server_path: '/usr/lib/ssh/sftp-server'
 ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  KbdInteractiveAuthentication: 'no'

--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -5,3 +5,5 @@ ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::service_name: 'com.openssh.sshd'
 ssh::sftp_server_path: '/usr/libexec/sftp-server'
 ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/Debian_10.yaml
+++ b/data/Debian_10.yaml
@@ -1,0 +1,3 @@
+---
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/Debian_11.yaml
+++ b/data/Debian_11.yaml
@@ -1,0 +1,3 @@
+---
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/Debian_12.yaml
+++ b/data/Debian_12.yaml
@@ -1,0 +1,3 @@
+---
+ssh::server::default_options:
+  KbdInteractiveAuthentication: 'no'

--- a/data/Debian_8.yaml
+++ b/data/Debian_8.yaml
@@ -1,0 +1,3 @@
+---
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/Debian_9.yaml
+++ b/data/Debian_9.yaml
@@ -1,0 +1,3 @@
+---
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/DragonFly.yaml
+++ b/data/DragonFly.yaml
@@ -6,3 +6,5 @@ ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/sftp-server'
 ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/Gentoo.yaml
+++ b/data/Gentoo.yaml
@@ -8,3 +8,5 @@ ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/lib64/misc/sftp-server'
 ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  KbdInteractiveAuthentication: 'no'

--- a/data/OpenBSD.yaml
+++ b/data/OpenBSD.yaml
@@ -7,7 +7,7 @@ ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/sftp-server'
 ssh::server::host_priv_key_group: 0
 ssh::server::default_options:
-  ChallengeResponseAuthentication: 'no'
+  KbdInteractiveAuthentication: 'no'
   X11Forwarding: 'yes'
   PrintMotd: 'no'
   AcceptEnv: 'LANG LC_*'

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -9,3 +9,5 @@ ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/libexec/openssh/sftp-server'
 ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/SLES.yaml
+++ b/data/SLES.yaml
@@ -1,3 +1,5 @@
 ---
 ssh::server::service_name: 'sshd'
 ssh::sftp_server_path: '/usr/lib/ssh/sftp-server'
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/SmartOS.yaml
+++ b/data/SmartOS.yaml
@@ -5,3 +5,5 @@ ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::service_name: 'svc:/network/ssh:default'
 ssh::sftp_server_path: 'internal-sftp'
 ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/Suse.yaml
+++ b/data/Suse.yaml
@@ -8,3 +8,5 @@ ssh::server::sshd_environments_file: '/etc/sysconfig/ssh'
 ssh::server::service_name: 'sshd'
 ssh::client::ssh_config: '/etc/ssh/ssh_config'
 ssh::server::host_priv_key_group: 0
+ssh::server::default_options:
+  ChallengeResponseAuthentication: 'no'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -28,7 +28,6 @@ ssh::server::issue_net              : '/etc/issue.net'
 ssh::knownhosts::collect_enabled    : true
 
 ssh::server::default_options:
-  ChallengeResponseAuthentication: 'no'
   X11Forwarding: 'yes'
   PrintMotd: 'no'
   AcceptEnv: 'LANG LC_*'


### PR DESCRIPTION

#### Pull Request (PR) description
<!--
The option ChallengeResponseAuthentication is deprecated since openssh 8.7 (https://www.openssh.com/txt/release-8.7)
-->

The new option is KbdInteractiveAuthentication, the change set the new option for new version, and keep the old option 
ChallengeResponseAuthentication for old version OS