### PR TITLE
Windows Compatibility

### DIFF
--- a/lib/facter/ssh_server_version.rb
+++ b/lib/facter/ssh_server_version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Facter.add('ssh_server_version_full') do
-  confine kernel: %w[Linux SunOS FreeBSD DragonFly Darwin]
+  confine kernel: %w[Linux SunOS FreeBSD DragonFly Darwin windows]
 
   setcode do
     if Facter::Util::Resolution.which('sshd')
@@ -15,13 +15,13 @@ Facter.add('ssh_server_version_full') do
                 first.
                 rstrip
 
-      version&.gsub(%r{^(OpenSSH_|Sun_SSH_)([^ ,]+).*$}, '\2')
+      version&.gsub(%r{^(OpenSSH_for_Windows_|OpenSSH_|Sun_SSH_)([^ ,]+).*$}, '\2')
     end
   end
 end
 
 Facter.add('ssh_server_version_major') do
-  confine kernel: %w[Linux SunOS FreeBSD DragonFly DragonFly Darwin]
+  confine kernel: %w[Linux SunOS FreeBSD DragonFly DragonFly Darwin windows]
   confine ssh_server_version_full: %r{\d+}
   setcode do
     version = Facter.value('ssh_server_version_full')

--- a/metadata.json
+++ b/metadata.json
@@ -101,6 +101,9 @@
     },
     {
       "operatingsystem": "AIX"
+    },
+    {
+      "operatingsystem": "Windows"
     }
   ],
   "requirements": [


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

This Pull Request adds the required modifications to the module for it to be compatible with the Windows Capability ("Optional Feature") `OpenSSH.Server`.

It adds a section to the `README.md` with an example on how to set it up on Windows.

I decided to _not_ add the additional installation and configuration steps to the module, because as I understand, the Windows Capability is not broadly available on every Windows Version. I believe it should be compatible with the chocolatey way of installation, but I have not tested this.

I had some problems with the windows specific permission / ownership system and I solved them by using the `puppetlabs-acl` puppet module, but looking at https://github.com/saz/puppet-ssh/pull/225 it might not be necessary. But as it stands, it works, and I don't really want to invest more time unless I have more knowledge that can be easily applied. That is to say, I heartily welcome suggestions, tips, tricks, hints etc..

I actually did not see https://github.com/saz/puppet-ssh/pull/225 up until today (when I was basically finished with my changes), and as some changes do seem to match 1to1, I consider them changes that should be merged regardless of the rest of my proposed changes. E.g. that file ownership is configurable, and that the already configurable sshd binary path is used for config file validation.

I have successfully tested my proposed changes on multiple freshly provisioned machines running Windows Server 2022.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->

Fixes https://github.com/saz/puppet-ssh/pull/225

#### Things left to do

- [x] add descriptions for new parameters
- [x] update `REFERENCE.md`
