### PR TITLE
ssh_instance: write more values as comma-separated strings

### DIFF
--- a/templates/ssh_instance.erb
+++ b/templates/ssh_instance.erb
@@ -40,7 +40,7 @@ ListenAddress <%= listen %>
 <%- v.keys.sort.each do |key| -%>
     <%- value = v[key] -%>
     <%- if value.is_a?(Array) -%>
-    <%- if ['ciphers', 'macs', 'kexalgorithms', 'gssapikexalgorithms', 'hostbasedacceptedkeytypes', 'hostkeyalgorithms', 'pubkeyacceptedkeytypes'].include?(key.downcase) -%>
+    <%- if ['ciphers', 'macs', 'kexalgorithms', 'gssapikexalgorithms', 'hostbasedacceptedkeytypes', 'hostbasedacceptedalgorithms', 'hostkeyalgorithms', 'pubkeyacceptedkeytypes', 'pubkeyacceptedalgorithms'].include?(key.downcase) -%>
     <%= key %> <%= value.join(',') %>
     <%- else -%>
     <%- value.each do |a| -%>
@@ -55,7 +55,7 @@ ListenAddress <%= listen %>
 <%- end -%>
 <%- else -%>
 <%- if v.is_a?(Array) -%>
-<%- if ['ciphers', 'macs', 'kexalgorithms', 'gssapikexalgorithms', 'hostbasedacceptedkeytypes', 'hostkeyalgorithms', 'pubkeyacceptedkeytypes'].include?(k.downcase) -%>
+<%- if ['ciphers', 'macs', 'kexalgorithms', 'gssapikexalgorithms', 'hostbasedacceptedkeytypes', 'hostbasedacceptedalgorithms', 'hostkeyalgorithms', 'pubkeyacceptedkeytypes', 'pubkeyacceptedalgorithms'].include?(k.downcase) -%>
 <%= k %> <%= v.join(',') %>
 <%- else -%>
 <%- v.each do |a| -%>

--- a/templates/ssh_instance.erb
+++ b/templates/ssh_instance.erb
@@ -40,7 +40,7 @@ ListenAddress <%= listen %>
 <%- v.keys.sort.each do |key| -%>
     <%- value = v[key] -%>
     <%- if value.is_a?(Array) -%>
-    <%- if ['ciphers', 'macs', 'kexalgorithms'].include?(key.downcase) -%>
+    <%- if ['ciphers', 'macs', 'kexalgorithms', 'gssapikexalgorithms', 'hostbasedacceptedkeytypes', 'hostkeyalgorithms', 'pubkeyacceptedkeytypes'].include?(key.downcase) -%>
     <%= key %> <%= value.join(',') %>
     <%- else -%>
     <%- value.each do |a| -%>
@@ -55,7 +55,7 @@ ListenAddress <%= listen %>
 <%- end -%>
 <%- else -%>
 <%- if v.is_a?(Array) -%>
-<%- if ['ciphers', 'macs', 'kexalgorithms'].include?(k.downcase) -%>
+<%- if ['ciphers', 'macs', 'kexalgorithms', 'gssapikexalgorithms', 'hostbasedacceptedkeytypes', 'hostkeyalgorithms', 'pubkeyacceptedkeytypes'].include?(k.downcase) -%>
 <%= k %> <%= v.join(',') %>
 <%- else -%>
 <%- v.each do |a| -%>


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Write gssapikexalgorithms, hostbasedacceptedkeytypes, hostbasedacceptedalgorithms, hostkeyalgorithms, pubkeyacceptedkeytypes, pubkeyacceptedalgorithms as comma-separated string.

As the man page of [sshd_config(5)](https://man7.org/linux/man-pages/man5/sshd_config.5.html) describes, these parameters should be written as comma-separated string.
This expands the fix already implemented in https://github.com/saz/puppet-ssh/pull/401

