### PR TITLE
Need to create $issue_net variable in ssh::server class

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -580,6 +580,7 @@ The following parameters are available in the `ssh::server` class:
 * [`options_absent`](#-ssh--server--options_absent)
 * [`match_block`](#-ssh--server--match_block)
 * [`use_issue_net`](#-ssh--server--use_issue_net)
+* [`issue_net`](#-ssh--server--issue_net)
 * [`sshd_environments_file`](#-ssh--server--sshd_environments_file)
 * [`server_package_name`](#-ssh--server--server_package_name)
 
@@ -744,6 +745,12 @@ Data type: `Boolean`
 Add issue_net banner
 
 Default value: `false`
+
+##### <a name="-ssh--server--issue_net"></a>`issue_net`
+
+Data type: `Stdlib::Absolutepath`
+
+Path to the issue.net file
 
 ##### <a name="-ssh--server--sshd_environments_file"></a>`sshd_environments_file`
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -77,6 +77,9 @@
 # @param use_issue_net
 #   Add issue_net banner
 #
+# @param issue_net
+#   Path to the issue.net file
+#
 # @param sshd_environments_file
 #   Path to a sshd environments file (e.g. /etc/defaults/ssh on Debian)
 #
@@ -85,6 +88,7 @@
 #
 class ssh::server (
   String[1]                      $service_name,
+  Stdlib::Absolutepath           $issue_net
   Stdlib::Absolutepath           $sshd_config,
   Stdlib::Absolutepath           $sshd_dir,
   Stdlib::Absolutepath           $sshd_binary,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -88,7 +88,7 @@
 #
 class ssh::server (
   String[1]                      $service_name,
-  Stdlib::Absolutepath           $issue_net
+  Stdlib::Absolutepath           $issue_net,
   Stdlib::Absolutepath           $sshd_config,
   Stdlib::Absolutepath           $sshd_dir,
   Stdlib::Absolutepath           $sshd_binary,


### PR DESCRIPTION
This is needed in order for class ssh::server::config to be able to find the variable.

#### Pull Request (PR) description
This is needed in order for class ssh::server::config to be able to find the variable.
#### This Pull Request (PR) fixes the following issues
if you attempt to set 'use_issue_net        => true,' in the main class { 'ssh':} you will get the following error: 'Error: Unknown variable: 'ssh::server::issue_net'. ......modules/ssh/manifests/server/config.pp, line: 69, column: 12'