### PR TITLE
Add issue_net_content parameter to allow custom banner content

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -580,6 +580,7 @@ The following parameters are available in the `ssh::server` class:
 * [`options_absent`](#-ssh--server--options_absent)
 * [`match_block`](#-ssh--server--match_block)
 * [`use_issue_net`](#-ssh--server--use_issue_net)
+* [`issue_net`](#-ssh--server--issue_net)
 * [`sshd_environments_file`](#-ssh--server--sshd_environments_file)
 * [`server_package_name`](#-ssh--server--server_package_name)
 
@@ -744,6 +745,12 @@ Data type: `Boolean`
 Add issue_net banner
 
 Default value: `false`
+
+##### <a name="-ssh--server--issue_net"></a>`issue_net`
+
+Data type: `Stdlib::Absolutepath`
+
+Path to the issue.net file
 
 ##### <a name="-ssh--server--sshd_environments_file"></a>`sshd_environments_file`
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -77,6 +77,9 @@
 # @param use_issue_net
 #   Add issue_net banner
 #
+# @param issue_net
+#   Path to the issue.net file
+#
 # @param sshd_environments_file
 #   Path to a sshd environments file (e.g. /etc/defaults/ssh on Debian)
 #
@@ -85,6 +88,7 @@
 #
 class ssh::server (
   String[1]                      $service_name,
+  Stdlib::Absolutepath           $issue_net
   Stdlib::Absolutepath           $sshd_config,
   Stdlib::Absolutepath           $sshd_dir,
   Stdlib::Absolutepath           $sshd_binary,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -88,7 +88,7 @@
 #
 class ssh::server (
   String[1]                      $service_name,
-  Stdlib::Absolutepath           $issue_net
+  Stdlib::Absolutepath           $issue_net,
   Stdlib::Absolutepath           $sshd_config,
   Stdlib::Absolutepath           $sshd_dir,
   Stdlib::Absolutepath           $sshd_binary,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -80,6 +80,10 @@
 # @param issue_net
 #   Path to the issue.net file
 #
+# @param issue_net_content
+#   Content of the issue.net file. If undef (default), uses the template.
+#   If set to a string, uses that content instead of the template.
+#
 # @param sshd_environments_file
 #   Path to a sshd environments file (e.g. /etc/defaults/ssh on Debian)
 #
@@ -111,6 +115,7 @@ class ssh::server (
   Array                          $options_absent         = [],
   Hash                           $match_block            = {},
   Boolean                        $use_issue_net          = false,
+  Optional[String]               $issue_net_content      = undef,
   Optional[Stdlib::Absolutepath] $sshd_environments_file = undef,
   Optional[String[1]]            $server_package_name    = undef,
 ) {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -66,12 +66,18 @@ class ssh::server::config {
   }
 
   if $ssh::server::use_issue_net {
+    if $ssh::server::issue_net_content {
+      $issue_net_content_real = $ssh::server::issue_net_content
+    } else {
+      $issue_net_content_real = template("${module_name}/issue.net.erb")
+    }
+
     file { $ssh::server::issue_net:
       ensure  => file,
       owner   => $ssh::server::config_user,
       group   => $ssh::server::config_group,
       mode    => $ssh::server::sshd_config_mode,
-      content => template("${module_name}/issue.net.erb"),
+      content => $issue_net_content_real,
       notify  => Service[$ssh::server::service_name],
     }
 


### PR DESCRIPTION
This PR adds a new optional parameter `issue_net_content` to the `ssh::server` class that allows users to override the default issue.net template with custom content.
  
  **Changes:**
  - Add `issue_net_content` parameter (Optional[String], defaults to undef)
  - When undef, uses the existing template (backward compatible)
  - When set, uses the provided string content instead of the template
  - Updated documentation in manifests/server.pp
  
  **Backward Compatibility:**
  ✅ Fully backward compatible - existing configurations will continue to work unchanged
