### PR TITLE
hostkeys: Properly set name of created sshkey objects

### DIFF
--- a/manifests/hostkeys.pp
+++ b/manifests/hostkeys.pp
@@ -51,9 +51,9 @@ class ssh::hostkeys (
   if $export_ipaddresses == true {
     $ipaddresses = ssh::ipaddresses($exclude_interfaces, $exclude_interfaces_re)
     $ipaddresses_real = $ipaddresses - $exclude_ipaddresses
-    $host_aliases = sort(unique(flatten([$fqdn_real, $hostname_real, $extra_aliases, $ipaddresses_real])))
+    $host_aliases = sort(unique(flatten([$hostname_real, $extra_aliases, $ipaddresses_real])))
   } else {
-    $host_aliases = sort(unique(flatten([$fqdn_real, $hostname_real, $extra_aliases])))
+    $host_aliases = sort(unique(flatten([$hostname_real, $extra_aliases])))
   }
 
   $storeconfigs_groups = $storeconfigs_group ? {
@@ -77,6 +77,7 @@ class ssh::hostkeys (
     if $key_type in $facts['ssh'] {
       @@sshkey { "${fqdn_real}_${key_type}":
         ensure       => present,
+        name         => $fqdn_real,
         host_aliases => $host_aliases,
         type         => $facts['ssh'][$key_type]['type'],
         key          => $facts['ssh'][$key_type]['key'],


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
By default, the sshkey resource assumes the resource title is a hostname that should end up in the known hosts file, so with the current setup hosts like `some.fdqn.example_ed25519` are ending up in there which is wrong and messes up tab completion and similar.

This PR removes those incorrect names by updating the resource to override the name attribute to the host FQDN instead of relying on the default resource title and setting the host FQDN as an alias.

#### This Pull Request (PR) fixes the following issues
n/a
